### PR TITLE
Put back return of versions array from moosh_generate_version_list

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -201,6 +201,7 @@ function moosh_generate_version_list($upto, $from = 19)
     foreach( range($from, $upto) as $no) {
         $versions[] = 'Moodle'.$no;
     }
+    return $versions;
 }
 
 /**


### PR DESCRIPTION
Without this, only the Generic commands are displayed and accessible.
