### PR TITLE
Added option to set maildigest field and fixed bug

### DIFF
--- a/Moosh/Command/Moodle23/User/UserCreate.php
+++ b/Moosh/Command/Moodle23/User/UserCreate.php
@@ -17,13 +17,14 @@ class UserCreate extends MooshCommand
     {
         parent::__construct('create', 'user');
         $this->addOption('a|auth:', 'authentication plugin, e.g. ldap');
-        $this->addOption('p|password:', 'password');
+        $this->addOption('p|password:', 'password (NONE for a blank password)');
         $this->addOption('e|email:','email address');
         $this->addOption('c|city:','city');
         $this->addOption('C|country:','country');
         $this->addOption('f|firstname:','first name');
         $this->addOption('l|lastname:','last name');
         $this->addOption('i|idnumber:','idnumber');
+        $this->addOption('d|digest:', 'mail digest type as int (0=No digest, 1=Compelte, 2=Subjects)');
 
         $this->addArgument('username');
         $this->maxArguments = 255;
@@ -40,11 +41,24 @@ class UserCreate extends MooshCommand
             $this->expandOptionsManually(array($argument));
             $options = $this->expandedOptions;
             $user = new \stdClass();
-            $user->auth = $options['auth'];
-            if($options['password']){ // needed to stop errors when creating an LDAP user
-                $user->password = $options['password'];
+            if($options['auth']){
+                $user->auth = $options['auth'];
             }
+            // new version of GetOptionKit does not allow a blank string as input
+            // to -p or --password, so 'magic' value NONE is needed to allow
+            // an explicitly blank password be specified, which needs to be 
+            // possible when specifying an auth type of ldap - Bart Busschots 2 Sep 2013
+            $password = $options['password'];
+            if($password == 'NONE'){ // needed to stop errors when trying to set empty PW
+                $password = '';
+            }
+            $user->password = $password;
             $user->email = $options['email'];
+            $maildigest = 0;
+            if($options['digest'] && is_numeric($options['digest']) && $options['digest'] > 0 && $options['digest'] <= 2){
+                $maildigest = $options['digest'];
+            }
+            $user->maildigest = $maildigest;
             $user->city = $options['city'];
             $user->country = $options['country'];
             $user->firstname = $options['firstname'];
@@ -60,7 +74,7 @@ class UserCreate extends MooshCommand
             // to prevent errors about insufficiently strong passwords, use a
             // direct DB insert rather than an API call when adding a user
             // with external auth and no password specified
-            if($options['auth'] && $options['auth'] != "manual" && !$options['password']){
+            if($options['auth'] && $options['auth'] != "manual" && !$password){
                 $newuserid = $DB->insert_record('user', $user);
             }else{
                 $newuserid = user_create_user($user);

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Example 1: create user "testuser" with the all default profile fields.
 
 Example 2: create user "testuser" with the all the optional values
 
-    moosh user-create --password pass --email me@example.com --city Szczecin --country PL --firstname "first name" --lastname name testuser
+    moosh user-create --password pass --email me@example.com --digest 2 --city Szczecin --country PL --firstname "first name" --lastname name testuser
 
 Example 3: use bash/zsh expansion to create 10 users
 
@@ -70,7 +70,7 @@ The users will have unique email addresses based on the user name (testuser1, te
 
 Example 4: create a user with LDAP authentication
 
-    moosh user-create --auth ldap --password ""  --email joe.blogs@domain.tld --city "Some City" --country IE --firstname "Joe" --lastname "Blogs" jblogs
+    moosh user-create --auth ldap --password NONE  --email joe.blogs@domain.tld --city "Some City" --country IE --firstname "Joe" --lastname "Blogs" jblogs
 
 
 user-delete


### PR DESCRIPTION
Added --digest option to set the maildigest field in the users table
when createing a user.

Also fixed a problem that seems to have been introduced by an update to
the GetOptionKit library. In the past a blank password could be forced
with --password '', but that now throws a GetOptionKit exception. Added
'magic word' NONE for explicitly setting a blank password (needed for
creating LDAP users)
