### PR TITLE
Fixed course-config-set Command

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseConfigSet.php
+++ b/Moosh/Command/Moodle23/Course/CourseConfigSet.php
@@ -24,8 +24,6 @@ class CourseConfigSet extends MooshCommand
 
     public function execute()
     {
-        global $DB;
-
         $setting = trim($this->arguments[2]);
         $value = trim($this->arguments[3]);
 
@@ -37,9 +35,19 @@ class CourseConfigSet extends MooshCommand
             case 'category':
                 //get all courses in category (recursive)
                 $courselist = get_courses($this->arguments[1]/* categoryid */,'','c.id');
+                $succeeded = 0;
+                $failed = 0;
                 foreach ($courselist as $course) {
-                    echo "debug: courseid=$course->id , $setting=$value\n";
-                    self::setCourseSetting($course->id,$setting,$value);
+                    if(self::setCourseSetting($course->id,$setting,$value)){
+                        $succeeded++;
+                    }else{
+                        $failed++;
+                    }
+                }
+                if($failed == 0){
+                    echo "OK - successfully modified $succeeded courses\n";
+                }else{
+                    echo "WARNING - failed to mofify $failed courses (successfully modified $succeeded)\n";
                 }
                 break;
         }
@@ -47,11 +55,14 @@ class CourseConfigSet extends MooshCommand
     }
 
     private function setCourseSetting($courseid,$setting,$value) {
+        
+        global $DB;
+        
         if ($DB->set_field('course',$setting,$value,array('id'=>$courseid))) {
-            echo "debug: Success (courseid={$courseid})\n";
+            echo "OK - Set $setting='$value' (courseid={$courseid})\n";
             return true;
         } else {
-            echo "debug: Fail (courseid={$courseid})\n";
+            echo "ERROR - failed to set $setting='$value' (courseid={$courseid})\n";
             return false;
         }
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,18 @@ Example 1: Reset course with id=17
 
     moosh course-reset 17
 
+course-config-set
+-----------------
+
+Update a field in the Moodle {course} table for a single course, or for all courses in a category.
+
+Example 1: set the shortname of a single course with id=42
+
+    moosh course-config-set course 42 shortname new_shortname
+    
+Example 2: set the format to topics for all courses in a category with id=7
+
+    moosh course-config-set category 7 format topics
 
 role-create
 -----------


### PR DESCRIPTION
There was a bug in this command which caused it to always fail ($DB had
not been declared global in the private function to alter the DB).

While fixing the bug I also noticed that the command had debugging
print statements left in place. I replaced those with useful feedback
for users.

Finally, I added a description of the Command to the readme file,
because it was missing.
