### PR TITLE
Pass option before mode for BSD chmod compatibility

### DIFF
--- a/tests/restore_all.sh
+++ b/tests/restore_all.sh
@@ -31,7 +31,7 @@ for V in $VERSIONS; do
     cd $GITCHECKOUT/data
     tar -xf moodledata$V.tar.bz2
     mv moodledata$V $DATA
-    chmod 777 -R $DATA/moodledata$V
+    chmod -R 777 $DATA/moodledata$V
 
     #apply
     echo "CREATE DATABASE $DB$V" | mysql -u "$DBUSER" -p"$DBPASSWORD"


### PR DESCRIPTION
Minor tweak to prevent BSD chmod falling over - still compatible with GNU chmod.
