### PR TITLE
Fixed bug in sql-dump command

### DIFF
--- a/Moosh/Command/Moodle23/Sql/SqlDump.php
+++ b/Moosh/Command/Moodle23/Sql/SqlDump.php
@@ -23,7 +23,7 @@ class SqlDump extends MooshCommand
 
         switch ($CFG->dbtype) {
             case 'mysqli':
-                passthru("mysqldump -h {$CFG->dbhost} -u {$CFG->dbuser} -p{$CFG->dbpass} {$CFG->dbname}");
+                passthru("mysqldump -h {$CFG->dbhost} -u {$CFG->dbuser} --password='{$CFG->dbpass}' {$CFG->dbname}");
                 break;
             case 'pgsql':
                 $portoption = '';


### PR DESCRIPTION
Passwords containing shell special characters like $ were causing this
command to fail because the password was not being quoted, but passed
through to the shell raw. changed from -p to the more explicit
--password='password' form. Now works with most special characters.
