### PR TITLE
Course Create now respects default course format

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseCreate.php
+++ b/Moosh/Command/Moodle23/Course/CourseCreate.php
@@ -40,7 +40,11 @@ class CourseCreate extends MooshCommand
             $course->fullname = $options['fullname'];
             $course->shortname = $argument;
             $course->description = $options['description'];
-            $course->format = $options['format'];
+            $format = $options['format'];
+            if(!$format){
+            	$format = get_config('moodlecourse', 'format');
+            }
+            $course->format = $format;
             $course->idnumber = $options['idnumber'];
             $visible = strtolower($options['visible']);
             if($visible == 'n' || $visible == 'no' ){

--- a/includes/default_options.php
+++ b/includes/default_options.php
@@ -24,7 +24,6 @@ $defaultOptions['role']['description'] = '%s';
 
 $defaultOptions['course']['fullname'] = '%s';
 $defaultOptions['course']['description'] = '%s';
-$defaultOptions['course']['format'] = 'weeks';
 $defaultOptions['course']['visible'] = 1;
 $defaultOptions['course']['category'] = 1;
 


### PR DESCRIPTION
Course Create command had a hard-coded default of 'weeks', which meant
that default configured in Admin->Courses->Course Default
Settings->Format was not respected.

Removed the hard-coded default, and updated the command to use the
value of the setting variable moodlecourse | format when the -F flag is
not specified.
