### PR TITLE
Added exit code on error

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseConfigSet.php
+++ b/Moosh/Command/Moodle23/Course/CourseConfigSet.php
@@ -31,7 +31,7 @@ class CourseConfigSet extends MooshCommand
             case 'course':
                 if(!self::setCourseSetting($this->arguments[1]/* courseid */,$setting,$value)){
                 	// the setting was not applied, exit with a non-zero exit code
-                	exit(1);
+                	cli_error('');
                 }
                 break;
             case 'category':


### PR DESCRIPTION
Added a non-zero exit code on error when processing just a single module. This makes scripting with this moosh command more robust.
