### PR TITLE
Use corneltek/getoptionkit instead of non longer maintened c9s/GetOption...

### DIFF
--- a/Moosh/MooshCommand.php
+++ b/Moosh/MooshCommand.php
@@ -133,7 +133,7 @@ class MooshCommand
 
     public function __construct($name, $group = NULL)
     {
-        $this->spec = new \GetOptionKit\OptionSpecCollection();
+        $this->spec = new \GetOptionKit\OptionCollection();
         $this->addOption('h|help', 'help information');
         $this->name = $name;
         $this->group = $group;

--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
         }
     ],
     "require":{
-        "c9s/GetOptionKit":"1.2.*",
+        "corneltek/getoptionkit":"dev-master",
         "twig/twig":"1.*",
         "moodlehq/moodle-mod_newmodule":"dev-master#887786145a472e190eab3cc1dad29e22c948cb8f",
         "danielneis/moodle-block_newblock":"dev-master#1fc89fb0845ad282426140feeb6bc3653efd1d7f",

--- a/moosh
+++ b/moosh
@@ -1,0 +1,1 @@
+/home/cb/moosh/moosh

--- a/moosh.php
+++ b/moosh.php
@@ -32,7 +32,7 @@ require_once $moosh_dir . '/includes/default_options.php';
 
 
 use GetOptionKit\ContinuousOptionParser;
-use GetOptionKit\OptionSpecCollection;
+use GetOptionKit\OptionCollection;
 
 @error_reporting(E_ALL | E_STRICT);
 @ini_set('display_errors', '1');
@@ -40,7 +40,7 @@ use GetOptionKit\OptionSpecCollection;
 define('MOOSH_VERSION', '0.17');
 define('MOODLE_INTERNAL', true);
 
-$appspecs = new OptionSpecCollection;
+$appspecs = new OptionCollection;
 $spec_verbose = $appspecs->add('v|verbose', "be verbose");
 $spec_moodle_path = $appspecs->add('p|moodle-path:', "Moodle directory.");
 $spec_moodle_user = $appspecs->add('u|user:', "Moodle user, by default ADMIN");
@@ -113,7 +113,9 @@ if (!$subcommand && !$possible_matches) {
     echo implode("\n\t", array_keys($subcommands));
     echo "\n";
     echo "Global options:\n";
-    $appspecs->printOptions();
+    //$appspecs->printOptions();
+    $printer = new GetOptionKit\OptionPrinter\ConsoleOptionPrinter;
+    echo $printer->render($appspecs);
     echo "\n";
     exit(1);
 }


### PR DESCRIPTION
See #issue 61 : PHP fatal error install using source latests version

use corneltek/getoptionkit instead of non longer maintenad c9s/GetOptionKIT

