### PR TITLE
Twig dependency prevents install with PHP < 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
     ],
     "require":{
         "corneltek/getoptionkit":"dev-master#13a146e0f7b9161977332279dff894fa28c53168",
-        "twig/twig":"dev-master#4cf7464348e7f9893a93f7096a90b73722be99cf",
+        "twig/twig": "1.*@dev",
         "moodlehq/moodle-mod_newmodule":"dev-master#887786145a472e190eab3cc1dad29e22c948cb8f",
         "danielneis/moodle-block_newblock":"dev-master#1fc89fb0845ad282426140feeb6bc3653efd1d7f",
         "jamiepratt/moodle-qtype_TEMPLATE":"dev-master#bf2b7bc641c1db5c4889e4cc78ee3c2225398871",


### PR DESCRIPTION
Just provisioned up a new Vagrant box today based on an Ubuntu 12.04 and found that Moosh installation is failing as [Twig dev-master](https://packagist.org/packages/twig/twig) now requires PHP >= 5.5

I've used the same Ansible provisioning playbook a number of times in the past on Ubuntu 12.04 boxes so seems like this is caused by a recent update to Twig. The 1.x dev only requires >=5.2.7

Just as a note I haven't been able to run the unit tests as had difficulty getting them set up on OSX in the past.