### PR TITLE
add admin-login command

### DIFF
--- a/Moosh/Command/Moodle26/Admin/AdminLogin.php
+++ b/Moosh/Command/Moodle26/Admin/AdminLogin.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * `moosh admin-login`
+ *
+ * @copyright  2012 onwards Tomasz Muras
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle26\Admin;
+use Moosh\MooshCommand;
+
+class AdminLogin extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('login', 'admin');
+        $this->maxArguments = 2;
+    }
+
+    public function bootstrapLevel() {
+      # set to no client. when CLI_SCRIPT is defined, moodle creates an empty session
+      return self::$BOOTSTRAP_FULL_NOCLI;
+    }
+
+    public function execute() {
+        global $CFG, $DB;
+
+        require_once("$CFG->libdir/authlib.php");
+        require_once("$CFG->dirroot/login/lib.php");
+        $user = get_complete_user_data('username', $CFG->admin, $CFG->mnet_localhost_id);
+        if (!$user) {
+          cli_error(sprintf("Unable to find admin user in DB. Check config.php for correct \$CFG->admin. Current value is: '%s'", $CFG->admin));
+        }
+        $auth = empty($user->auth) ? 'manual' : $user->auth;
+        if ($auth=='nologin' or !is_enabled_auth($auth)) {
+          cli_error(sprintf("User authentication is either 'nologin' or disabled. Check config.php for correct \$CFG->admin or change in Moodle authentication method for '%s'", $user->username));
+        }
+        $authplugin = get_auth_plugin($auth);
+        $authplugin->sync_roles($user);
+        login_attempt_valid($user);
+        complete_user_login($user);
+        printf("%s:%s\n", session_name(), session_id());
+    }
+}

--- a/Moosh/MooshCommand.php
+++ b/Moosh/MooshCommand.php
@@ -38,7 +38,10 @@ class MooshCommand
      */
     public static $BOOTSTRAP_FULL = 2;
 
-
+    /**
+     * @var int no CLI_SCRIPT, include config.php
+     */
+    public static $BOOTSTRAP_FULL_NOCLI = 3;
 
 
     /**

--- a/moosh.php
+++ b/moosh.php
@@ -169,8 +169,16 @@ if ($moodlerc) {
 $subcommand = $subcommands[$subcommand];
 
 
-if ($subcommand->bootstrapLevel()) {
-    define('CLI_SCRIPT', true);
+if ($bootstrap_level = $subcommand->bootstrapLevel()) {
+    if ($bootstrap_level == MooshCommand::$BOOTSTRAP_FULL_NOCLI) {
+        $_SERVER['REMOTE_ADDR'] = 'localhost';
+        $_SERVER['SERVER_PORT'] = 80;
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP 1.1';
+        $_SERVER['SERVER_SOFTWARE'] = 'PHP/'.phpversion() ;
+        $_SERVER['REQUEST_URI'] = '/';
+    } else {
+        define('CLI_SCRIPT', true);
+    }
     if ($subcommand->bootstrapLevel() == MooshCommand::$BOOTSTRAP_CONFIG) {
         define('ABORT_AFTER_CONFIG', true);
     }


### PR DESCRIPTION
the "admin-login" command logins the "admin" user, creates a moodle session, and returns a {cookie name} - {cookie value} pair. It's possible then to use the cookie to download a Moodle page that requires authentication, such as the notification page