### PR TITLE
150618 make config set more robust

### DIFF
--- a/Moosh/Command/Moodle23/Config/ConfigSet.php
+++ b/Moosh/Command/Moodle23/Config/ConfigSet.php
@@ -35,6 +35,12 @@ class ConfigSet extends MooshCommand
         if (isset($this->arguments[2])) {
             $plugin = trim($this->arguments[2]);
         }
+        
+        // if the plugin is 'moodle' or 'core', set to NULL, otherwise call to 
+        // set_config will not behave as expected
+        if($plugin == 'moodle' || $plugin == 'core'){
+        	$plugin = NULL;
+        }
 
         set_config($name, $value, $plugin);
 

--- a/moosh.php
+++ b/moosh.php
@@ -191,6 +191,10 @@ if ($bootstrap_level = $subcommand->bootstrapLevel()) {
 
     $shell_user = false;
     if (!$app_options->has('no-user-check')) {
+    	// make sure the PHP POSIX library is installed before using it
+    	if(!(function_exists('posix_getpwuid') && function_exists('posix_geteuid'))){
+    		cli_error("The PHP POSIX extension is not installed - see http://php.net/manual/en/book.posix.php (on CentOS/RHEL the package php-process provides this extension)");
+    	}
         $shell_user = posix_getpwuid(posix_geteuid());
         $moodledata_owner = detect_moodledata_owner($CFG->dataroot);
         if($moodledata_owner && $shell_user['name'] != $moodledata_owner['user']['name']) {


### PR DESCRIPTION
config-get uses the plugin names 'moodle' and 'core' to refer to the mdl_config table, and all other plugin names to refer to the mdl_config_plugins table. config-set does not behave the same way - it ONLY treates the absense of a plugin as referring to the mdl_config table. This results in inconsistent behaviour between config-get and config-set which can be very confusing.

The addition of a simple if statement removes this confusion.