### PR TITLE
Add plugin installation location logic

### DIFF
--- a/Moosh/Command/Generic/Plugin/PluginInstall.php
+++ b/Moosh/Command/Generic/Plugin/PluginInstall.php
@@ -28,7 +28,6 @@ class PluginInstall extends MooshCommand
         require_once($CFG->libdir.'/upgradelib.php');     // general upgrade/install related functions
         require_once($CFG->libdir.'/environmentlib.php');
         require_once($CFG->dirroot.'/course/lib.php');
-        require_once($CFG->libdir.'/classes/plugin_manager.php');
 
         $pluginname = $this->arguments[0];
         $moodleversion = $this->arguments[1];


### PR DESCRIPTION
This is an attempt at fixing #114.

I think we should consider moving the plugin-install command into Moodle20 or Moodle26 as the method for determining plugin installation locations was introduced in 2.0 and changed in 2.6.

This command also makes use of /lib/upgradelib.php which was not introduced until 2.0. Which means it won't work in 1.9.