### PR TITLE
Moving 'generate-local' command to moodle 2.7

### DIFF
--- a/Moosh/Command/Moodle27/Dev/GenerateLocal.php
+++ b/Moosh/Command/Moodle27/Dev/GenerateLocal.php
@@ -6,7 +6,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace Moosh\Command\Moodle28\Dev;
+namespace Moosh\Command\Moodle27\Dev;
 use Moosh\MooshCommand;
 
 class GenerateLocal extends MooshCommand {


### PR DESCRIPTION
Works fine under 2.7 - should live here