### PR TITLE
Proposed fix for #132

### DIFF
--- a/Moosh/Command/Generic/Plugin/PluginInstall.php
+++ b/Moosh/Command/Generic/Plugin/PluginInstall.php
@@ -138,7 +138,6 @@ class PluginInstall extends MooshCommand
                 $downloadurl = null;
                 foreach($plugin->versions as $j) {
                     foreach($j->supportedmoodles as $v) {
-                        print "XXX {$v->version} vs $pluginversion\n";
                         if($v->release == $moodleversion) {
                             # Record the url for the most recent (assumed to be highest) 
                             # version of plugin that is compatible with the given Moodle 
@@ -156,7 +155,6 @@ class PluginInstall extends MooshCommand
                 # Negative pluginversion indicates we should return the latest version
                 # compatible with the given version of Moodle (recorded above)
                 if ($pluginversion < 0 and ! is_null($downloadurl)) {
-                    print "XXX returning $downloadurl\n";
                     return $downloadurl;
                 }
             }

--- a/Moosh/Command/Generic/Plugin/PluginInstall.php
+++ b/Moosh/Command/Generic/Plugin/PluginInstall.php
@@ -18,7 +18,7 @@ class PluginInstall extends MooshCommand
 
         $this->addArgument('plugin_name');
         $this->addArgument('moodle_version');
-        $this->addArgument('plugin_version');
+        $this->addArgument('plugin_version', ARG_GENERIC, true);
     }
 
     public function execute()
@@ -32,7 +32,11 @@ class PluginInstall extends MooshCommand
 
         $pluginname = $this->arguments[0];
         $moodleversion = $this->arguments[1];
-        $pluginversion = $this->arguments[2];
+        if (sizeof($this->arguments) >= 3) {
+            $pluginversion = $this->arguments[2];
+        } else {
+            $pluginversion = -1;                         // "use latest compatible version"
+        }
         $pluginsfile = home_dir() . '/.moosh/plugins.json';
 
         $stat = @stat($pluginsfile);
@@ -131,14 +135,29 @@ class PluginInstall extends MooshCommand
                 continue;
             }
             if($plugin->component == $pluginname) {
+                $downloadurl = null;
                 foreach($plugin->versions as $j) {
                     foreach($j->supportedmoodles as $v) {
-                        if($v->release == $moodleversion && $v->version == $pluginversion) {
+                        print "XXX {$v->version} vs $pluginversion\n";
+                        if($v->release == $moodleversion) {
+                            # Record the url for the most recent (assumed to be highest) 
+                            # version of plugin that is compatible with the given Moodle 
+                            # version...
                             $downloadurl = $j->downloadurl;
 
-                            return $downloadurl;
+                            # ...and return it if this version matches the given 
+                            # version.
+                            if ($pluginversion >= 0 && $v->version == $pluginversion) {
+                                return $downloadurl;
+                            } 
                         }
                     }
+                }
+                # Negative pluginversion indicates we should return the latest version
+                # compatible with the given version of Moodle (recorded above)
+                if ($pluginversion < 0 and ! is_null($downloadurl)) {
+                    print "XXX returning $downloadurl\n";
+                    return $downloadurl;
                 }
             }
         }

--- a/Moosh/MooshCommand.php
+++ b/Moosh/MooshCommand.php
@@ -160,11 +160,15 @@ class MooshCommand
      * Define required argument. Call function again to add another argument.
      * @param string $name
      */
-    public function addArgument($name, $type = ARG_GENERIC)
+    public function addArgument($name, $type = ARG_GENERIC, $optional=false)
     {
-        $this->minArguments++;
         $this->maxArguments++;
-        $this->argumentNames[] = $name;
+        if ($optional) {
+            $this->minArguments++;
+            $this->argumentNames[] = $name;
+        } else {
+            $this->argumentNames[] = $name . " (optional)";
+        }
 
         if($type == ARG_EXISTING_FILENAME) {
             if ($name[0] != '/') {


### PR DESCRIPTION
It turns out #132 isn't exactly a bug. It works if you know the exact plugin version you want to install, but finding that for every plugin you want can be almost as tedious as just installing them all via the web interface. 

This fix attempts to resolve the problem by providing a reasonable default value for the plugin version by...
* Adding support for optional arguments
* Making plugin version an optional argument
* Making plugin version default to the latest version that is compatible with the given Moodle version