### PR TITLE
Avoid course creation or modification if precheck fail

### DIFF
--- a/Moosh/Command/Moodle29/Course/CourseRestore.php
+++ b/Moosh/Command/Moodle29/Course/CourseRestore.php
@@ -159,17 +159,20 @@ class CourseRestore extends MooshCommand {
             $setting = $task->get_setting('enrol_migratetomanual');
             $setting->set_value('1');
         }
-        $rc->execute_precheck();
 
-        if ($options['existing'] && $options['overwrite']) {
-            // If existing course shall be overwritten, delete current content
-            $deletingoptions = array();
-            $deletingoptions['keep_roles_and_enrolments'] = 0;
-            $deletingoptions['keep_groups_and_groupings'] = 0;
-            restore_dbops::delete_course_content($courseid, $deletingoptions);
+        if ($rc->execute_precheck()) {
+            if ($options['existing'] && $options['overwrite']) {
+                // If existing course shall be overwritten, delete current content
+                $deletingoptions = array();
+                $deletingoptions['keep_roles_and_enrolments'] = 0;
+                $deletingoptions['keep_groups_and_groupings'] = 0;
+                restore_dbops::delete_course_content($courseid, $deletingoptions);
+            }
+            $rc->execute_plan();
+        } else {
+            cli_error('Error while restoring the course');
         }
 
-        $rc->execute_plan();
         $rc->destroy();
 
         echo "New course ID for '$shortname': $courseid in category {$category->id}\n";


### PR DESCRIPTION
Hi, I realized that a course restoration may be failing without stop. This is causing a course reset or creation without restoration. To reproduce, see :
https://docs.moodle.org/31/en/Backup_and_restore_FAQ#Restore_stops_with_the_message_.22Trying_to_restore_user_xxxx_from_backup_file_will_cause_conflict.22

Here is the fix to avoid that.