### PR TITLE
Fix to apache-parse-perflog. Extending date timestamp regexp search

### DIFF
--- a/Moosh/Command/Generic/Apache/ApacheParsePerfLog.php
+++ b/Moosh/Command/Generic/Apache/ApacheParsePerfLog.php
@@ -96,7 +96,8 @@ class ApacheParsePerfLog extends MooshCommand
 
             //[Sun Dec 22 06:29:01 2013]
             //[Sun Dec 22 06:29:01.731010 2013]
-            $row['timestamp'] = $this->parse($line, ' (.*?)\]');
+            //[28-Jul-2016 13:54:36 Europe/Paris]
+            $row['timestamp'] = $this->parse($line, '\[(.*?)\]');
             $row['timestamp'] = preg_replace('/\.\d+/', '', $row['timestamp']);
 
             $tmp = date_parse($row['timestamp']);

--- a/Moosh/Command/Generic/Apache/ApacheParsePerfLog.php
+++ b/Moosh/Command/Generic/Apache/ApacheParsePerfLog.php
@@ -27,6 +27,7 @@ use Moosh\ApacheLogParser\Parser;
  langcountgetstring int(10) unsigned NOT NULL,
  db_reads int(10) unsigned NOT NULL,
  db_writes int(10) unsigned NOT NULL,
+ db_queries_time int(10) unsigned NOT NULL,
  ticks int(10) unsigned NOT NULL,
  user int(10) unsigned NOT NULL,
  sys int(10) unsigned NOT NULL,


### PR DESCRIPTION
Regexp now searches for timestamp in square brackets. Allows to parse different timestamps besides default one.

[28-Jul-2016 13:54:36 Europe/Paris]

-----
Result of date_parse

php -r 'print_r(date_parse("28-Jul-2016 13:54:36 Europe/Paris"));'  
Array
(
    [year] => 2016
    [month] => 7
    [day] => 28
    [hour] => 13
    [minute] => 54
    [second] => 36
    [fraction] => 0
    [warning_count] => 0
    [warnings] => Array
        (
        )

    [error_count] => 0
    [errors] => Array
        (
        )

    [is_localtime] => 1
    [zone_type] => 3
    [tz_id] => Europe/Paris
)
