### PR TITLE
Updated plugin-install to solely rely on plugin version, and checking…

### DIFF
--- a/Moosh/Command/Generic/Plugin/PluginInstall.php
+++ b/Moosh/Command/Generic/Plugin/PluginInstall.php
@@ -12,13 +12,29 @@ use Moosh\MooshCommand;
 
 class PluginInstall extends MooshCommand
 {
+    private $moodlerelease;
+    private $moodleversion;
+
     public function __construct()
     {
         parent::__construct('install', 'plugin');
 
         $this->addArgument('plugin_name');
-        $this->addArgument('moodle_version');
         $this->addArgument('plugin_version');
+
+        $this->addOption('f|force', 'Force installation even if current Moodle version is unsupported.');
+        $this->addOption('d|delete', 'If it already exists, automatically delete plugin before installing.');
+    }
+
+    private function init()
+    {
+        global $CFG;
+        $this->moodlerelease = moodle_major_version();
+        if (!is_float($this->moodlerelease)) {
+            $this->moodlerelease = floatval($this->moodlerelease);
+        }
+
+        $this->moodleversion = $CFG->version;
     }
 
     public function execute()
@@ -30,113 +46,144 @@ class PluginInstall extends MooshCommand
         require_once($CFG->libdir.'/environmentlib.php');
         require_once($CFG->dirroot.'/course/lib.php');
 
-        $pluginname = $this->arguments[0];
-        $moodleversion = $this->arguments[1];
-        $pluginversion = $this->arguments[2];
-        $pluginsfile = home_dir() . '/.moosh/plugins.json';
+        $this->init();
 
-        $stat = @stat($pluginsfile);
-        if(!$stat || time() - $stat['mtime'] > 60*60*24 || !$stat['size']) {
-            die("plugins.json file not found or too old. Run moosh plugin-list to download newest plugins.json file\n");
-        }
+        $pluginname     = $this->arguments[0];
+        $pluginversion  = $this->arguments[1];
 
-        $pluginsdata = file_get_contents($pluginsfile);
-        $decodeddata = json_decode($pluginsdata);
-        $downloadurl = NULL;
+        $downloadurl    = $this->get_plugin_url($pluginname, $pluginversion);
 
-        $downloadurl = $this->get_plugin_url($decodeddata, $pluginname, $moodleversion, $pluginversion);
+        $split          = explode('_', $pluginname, 2);
+        $type           = $split[0];
+        $component      = $split[1];
+        $tempdir        = home_dir() . '/.moosh/moodleplugins/';
+        $downloadedfile = $tempdir . $component . ".zip";
 
-        if(!$downloadurl) {
-            die("Couldn't find $pluginname $moodleversion\n");
-        }
-
-        $split = explode('_',$this->arguments[0],2);
-        $tempdir = home_dir() . '/.moosh/moodleplugins/';
-
-        if(!file_exists($tempdir)) {
+        if (!file_exists($tempdir)) {
             mkdir($tempdir);
         }
 
-        if (!fopen($tempdir . $split[1] . ".zip", 'w')) {
-            echo "Failed to save plugin.\n";
+        if (!fopen($downloadedfile, 'w')) {
+            echo "Failed to save plugin - check permissions on $tempdir.\n";
             return;
         }
 
         try {
-            file_put_contents($tempdir . $split[1] . ".zip", file_get_contents($downloadurl));
+            file_put_contents($downloadedfile, file_get_contents($downloadurl));
         }
         catch (Exception $e) {
-            echo "Failed to download plugin. " . $e . "\n";
-            return;
+            die("Failed to download plugin from $downloadurl. " . $e . "\n");
         }
 
-        run_external_command("unzip -o " . $tempdir . $split[1] . ".zip -d " . home_dir() . "/.moosh/moodleplugins/");
-        run_external_command("cp -r " . $tempdir . $split[1] . "/ " . $this->get_install_path($split[0], $moodleversion));
+        $installpath = $this->get_install_path($type);
+        $targetpath = $installpath . DIRECTORY_SEPARATOR . $component;
 
-        echo "Installing $pluginname $moodleversion\n";
+        if (file_exists($targetpath)) {
+            if ($this->expandedOptions['delete']) {
+                echo "Removing previously installed $pluginname from $targetpath\n";
+                run_external_command("rm -rf $targetpath");
+            } else {
+                die("Something already exists at $targetpath - please remove it and try again, or run with the -d option.\n");
+            }
+        }
+
+        run_external_command("unzip $downloadedfile -d $installpath");
+        run_external_command("rm $downloadedfile");
+
+        echo "Installing\n";
+        echo "\tname:    $pluginname\n";
+        echo "\tversion: $pluginversion\n";
         upgrade_noncore(true);
         echo "Done\n";
     }
-    
+
     /**
      * Get the relative path for a plugin given it's type
-     * 
+     *
      * @param string $type
      *   The plugin type (example: 'auth', 'block')
      * @param string $moodleversion
      *   The version of moodle we are running (example: '1.9', '2.9')
      * @return string
-     *   The installation path relative to dirroot (example: 'auth', 'blocks', 
+     *   The installation path relative to dirroot (example: 'auth', 'blocks',
      *   'course/format')
      */
-    private function get_install_path($type, $moodleversion)
+    private function get_install_path($type)
     {
         global $CFG;
-        
-        // Convert moodle version to a float for more acurate comparison
-        if (!is_float($moodleversion)) {
-            $moodleversion = floatval($moodleversion);
-        }        
-        
-        if ($moodleversion >= 2.6) {
+
+        if ($this->moodlerelease >= 2.6) {
             $types = \core_component::get_plugin_types();
-        } else if ($moodleversion >= 2.0) {
+        } else if ($this->moodlerelease >= 2.0) {
             $types = get_plugin_types();
         } else {
-            // Moodle 1.9 does not give us a way to determine plugin 
+            // Moodle 1.9 does not give us a way to determine plugin
             // installation paths.
             $types = array();
         }
-        
+
         if (empty($types) || !array_key_exists($type, $types)) {
             // Either the moodle version is lower than 2.0, in which case we
             // don't have a reliable way of determining the install path, or the
             // plugin is of an unknown type.
-            // 
+            //
             // Let's fall back to make our best guess.
-            return $CFG->dirroot . '/' . $type; 
+            return $CFG->dirroot . '/' . $type;
         }
-        
+
         return $types[$type];
     }
 
-    function get_plugin_url($pluginlist, $pluginname, $moodleversion, $pluginversion) {
-        foreach($pluginlist->plugins as $k=>$plugin) {
-            if(!$plugin->component) {
+    private function get_plugin_url($pluginname, $pluginversion)
+    {
+        $pluginlist = $this->get_plugins_data();
+
+        foreach ($pluginlist->plugins as $plugin) {
+            if (!$plugin->component) {
                 continue;
             }
-            if($plugin->component == $pluginname) {
-                foreach($plugin->versions as $j) {
-                    foreach($j->supportedmoodles as $v) {
-                        if($v->release == $moodleversion && $v->version == $pluginversion) {
-                            $downloadurl = $j->downloadurl;
+            if ($plugin->component == $pluginname) {
+                foreach ($plugin->versions as $version) {
+                    if ($version->version == $pluginversion) {
 
-                            return $downloadurl;
+                        if (!$this->expandedOptions['force'] && !$this->is_supported_by_moodle($version)) {
+                            $message = "This plugin is not supported for your Moodle version (release $this->moodlerelease - version $this->moodleversion). ";
+                            $message .= "Specify a different plugin version, or use the -f flag to force installation of (this) unsupported version.\n";
+                            die($message);
                         }
+
+                        return $version->downloadurl;
                     }
                 }
             }
         }
+
+        die("Couldn't find $pluginname $pluginversion\n");
+    }
+
+    private function is_supported_by_moodle($version)
+    {
+        foreach ($version->supportedmoodles as $supported) {
+            if ($this->moodlerelease == $supported->release && $this->moodleversion >= $supported->version) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function get_plugins_data()
+    {
+        $pluginsfile = home_dir() . '/.moosh/plugins.json';
+
+        $stat = @stat($pluginsfile);
+        if (!$stat || time() - $stat['mtime'] > 60*60*24 || !$stat['size']) {
+            die("plugins.json file not found or too old. Run moosh plugin-list to download newest plugins.json file\n");
+        }
+
+        $pluginsdata = file_get_contents($pluginsfile);
+        $decodeddata = json_decode($pluginsdata);
+
+        return $decodeddata;
     }
 }
 

--- a/Moosh/Command/Generic/Plugin/PluginList.php
+++ b/Moosh/Command/Generic/Plugin/PluginList.php
@@ -19,6 +19,7 @@ class PluginList extends MooshCommand
         parent::__construct('list', 'plugin');
 
         $this->addOption('p|path:', 'path to plugins.json file', home_dir() . '/.moosh/plugins.json');
+        $this->addOption('v|versions', 'display plugin versions instead of supported moodle versions');
     }
 
     public function execute()
@@ -50,10 +51,14 @@ class PluginList extends MooshCommand
             if(!$plugin->component) {
                 continue;
             }
-            $fulllist[$plugin->component] = array();
+            $fulllist[$plugin->component] = array('releases' => array());
             foreach($plugin->versions as $v=>$version) {
-                foreach($version->supportedmoodles as $supportedmoodle) {
-                    $fulllist[$plugin->component]['releases'][$supportedmoodle->release] = $version;
+                if ($this->expandedOptions['versions']) {
+                    $fulllist[$plugin->component]['releases'][$version->version] = $version;
+                } else {
+                    foreach($version->supportedmoodles as $supportedmoodle) {
+                        $fulllist[$plugin->component]['releases'][$supportedmoodle->release] = $version;
+                    }
                 }
                 $fulllist[$plugin->component]['url'] = $version->downloadurl;
             }

--- a/www/_site/commands/index.html
+++ b/www/_site/commands/index.html
@@ -1141,11 +1141,11 @@ moosh module-manage show scorm
 
 <h2><a class="command-name">plugin-install</a></h2>
 
-<p>Download and install plugin. Requires plugin short name, and moodle version. You can obtain those data by using `plugin-list' command.</p>
+<p>Download and install plugin. Requires plugin short name, and plugin version. You can obtain those data by using `plugin-list -v' command.</p>
 
 <p>Example:</p>
 
-<pre><code>moosh plugin-install mod_quickmail 10 
+<pre><code>moosh plugin-install mod_quickmail 20160101
 </code></pre>
 
 <p><span class="anchor" id="plugin-list"></span></p>

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -954,11 +954,11 @@ Example:
 <a class="command-name">plugin-install</a>
 ----------------
 
-Download and install plugin. Requires plugin short name, and moodle version. You can obtain those data by using `plugin-list' command. 
+Download and install plugin. Requires plugin short name, and plugin version. You can obtain those data by using `plugin-list -v' command.
 
 Example:
 
-    moosh plugin-install mod_quickmail 10 
+    moosh plugin-install mod_quickmail 20160101
 
 
 <span class="anchor" id="plugin-list"></span>


### PR DESCRIPTION
Updates the `plugin-install` command take two arguments: `plugin_name` and `plugin_version`.
It no longer expects a moodle version, as it will automatically detect the version in the cwd.

This command will check to see if the specified version is compatible with the current moodle release. If it's incompatible, you may use the `-f (--force)` flag to force installation. 
This command will also stop if the specified plugin already exists. In order to continue (eg. if you're upgrading the plugin to a newer version) you should specify the `-d (--delete)` flag, which will remove the existing plugin from the filesystem before extracting the new version in its place.

This patch also updates `plugin-list` and adds a `-v` option. If `-v` is passed to `plugin-list` you'll see plugin versions in the output, rather than supported moodle releases.

### Warning
This commit changes the `plugin-install` command syntax! Maybe a new command (`plugin-install-2`?) should be created instead?