### PR TITLE
Remove hardcoded version from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "tmuras/moosh",
     "description": "Moosh stands for MOOdle SHell. It is a command-line tool that will allow you to perform most common Moodle tasks.",
     "license": "GPL-3.0+",
-    "version": "0.18",
     "homepage": "http://moosh-online.com",
     "keywords": ["moodle", "shell", "cli"],
     "repositories":[


### PR DESCRIPTION
Composer will determine version based on git tag or git branches instead of all the time hardcoded same version (0.18).