### PR TITLE
SQL query run: SELECT c.id,c.category,c.shortname,c.fullname,c.visibl…

### DIFF
--- a/Moosh/Command/Moodle26/Course/CourseList.php
+++ b/Moosh/Command/Moodle26/Course/CourseList.php
@@ -56,7 +56,7 @@ class CourseList extends MooshCommand {
             $sql .= " LEFT JOIN {course_modules} m ON c.id=m.course ";
         }
 
-        $sql .= "WHERE 1 ";
+        $sql .= "WHERE '1' ";
         if ($options['categorysearch'] ) {
             $category = \coursecat::get($options['categorysearch']);
 


### PR DESCRIPTION
…e FROM {course} c WHERE 1  AND (shortname = 'BMA0041')

Params:
NULL
Default exception handler: Error reading from database Debug: ERROR: argument of AND must be type boolean, not type integer
LINE 1: ...name,c.fullname,c.visible FROM mdl_course c WHERE 1  AND (sh...
                                                             ^

https://www.postgresql.org/docs/current/static/datatype-boolean.html