### PR TITLE
 Reset maintenance_message after maintenance mode

### DIFF
--- a/Moosh/Command/Moodle23/Config/MaintenanceOff.php
+++ b/Moosh/Command/Moodle23/Config/MaintenanceOff.php
@@ -18,6 +18,7 @@ class MaintenanceOff extends MooshCommand
 
     public function execute()
     {
+        set_config('maintenance_mesage', '');
         set_config('maintenance_enabled', 0);
         echo "Maintenance Mode Disabled\n";
     }


### PR DESCRIPTION
So it's always keep empty. We need this because we use the two different maintenance modes. One using the climaintenance.template.html file and one using the UX-mode with the maintenance_message.