### PR TITLE
Fix WHERE to work on Oracle DB

### DIFF
--- a/Moosh/Command/Moodle26/Course/CourseList.php
+++ b/Moosh/Command/Moodle26/Course/CourseList.php
@@ -56,7 +56,7 @@ class CourseList extends MooshCommand {
             $sql .= " LEFT JOIN {course_modules} m ON c.id=m.course ";
         }
 
-        $sql .= "WHERE '1' ";
+        $sql .= "WHERE '1'='1' ";
         if ($options['categorysearch'] ) {
             $category = \coursecat::get($options['categorysearch']);
 


### PR DESCRIPTION
Avoid this error:
Default exception handler: Error reading from database Debug: ORA-00920: invalid relational operator
SELECT c.id,c.category,c.shortname,c.fullname,c.visible FROM mdl_course c WHERE '1'
Error code: dmlreadexception
* line 479 of /lib/dml/moodle_database.php: dml_read_exception thrown
* line 277 of /lib/dml/oci_native_moodle_database.php: call to moodle_database->query_end()
* line 1245 of /lib/dml/oci_native_moodle_database.php: call to oci_native_moodle_database->query_end()
* line 88 of /moosh/Moosh/Command/Moodle26/Course/CourseList.php: call to oci_native_moodle_database->get_records_sql()
* line 289 of /moosh/moosh.php: call to Moosh\Command\Moodle26\Course\CourseList->execute()