### PR TITLE
Add mariadb support to SqlDump command.

### DIFF
--- a/Moosh/Command/Moodle23/Sql/SqlDump.php
+++ b/Moosh/Command/Moodle23/Sql/SqlDump.php
@@ -28,6 +28,7 @@ class SqlDump extends MooshCommand
 
         switch ($CFG->dbtype) {
             case 'mysqli':
+            case 'mariadb':
                 $portoption = '';
                 if (!empty($CFG->dboptions['dbport'])) {
                     $portoption = '-P ' . $CFG->dboptions['dbport'];


### PR DESCRIPTION
SqlCli command supports mariadb but SqlDump does not. This pull request adds mariadb support to SqlDump.