### PR TITLE
add numsections option to course-create

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseCreate.php
+++ b/Moosh/Command/Moodle23/Course/CourseCreate.php
@@ -19,6 +19,7 @@ class CourseCreate extends MooshCommand
         $this->addOption('f|fullname:', 'full name');
         $this->addOption('d|description:', 'description');
         $this->addOption('F|format:', 'format (e.g. one of site, weeks, topics, etc.)');
+        $this->addOption('n|numsections:', 'number of sections (i.e. of weeks, topics, etc.)');
         $this->addOption('i|idnumber:', 'id number');
         $this->addOption('v|visible:', 'visible (y or n, by default created visible)');
         $this->addOption('r|reuse', 'reuse existing course if it is the only matching one', false);
@@ -46,6 +47,11 @@ class CourseCreate extends MooshCommand
             	$format = get_config('moodlecourse', 'format');
             }
             $course->format = $format;
+            $numsections = $options['numsections'];
+            if(!$numsections){
+            	$numsections = get_config('moodlecourse', 'numsections');
+            }
+            $course->numsections = $numsections;
             $course->idnumber = $options['idnumber'];
             $visible = strtolower($options['visible']);
             if($visible == 'n' || $visible == 'no' ){

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -475,6 +475,10 @@ Example 2: Create new course
 
     moosh course-create --category 1 --fullname "full course name" --description "course description" --idnumber "course idnumber" shortname
 
+Example 3: Create new course with section format, number options
+
+    moosh course-create --category 4 --format topics --numsections 2 test
+
 
 <span class="anchor" id="course-config-set"></span>
 <a class="command-name">course-config-set</a>


### PR DESCRIPTION
The patch forces course-create to follow the default course config setting for numsections, as master does already for format, if a new numsections option is not used.

Using the new option, you can specify other numsections values.

I think this is desirable, if you are using course-create on a production site.

The index.md patch documents in addition the format option, which behaves similarly.