### PR TITLE
Fix typo in maintenance-off cmd

### DIFF
--- a/Moosh/Command/Moodle23/Config/MaintenanceOff.php
+++ b/Moosh/Command/Moodle23/Config/MaintenanceOff.php
@@ -18,7 +18,7 @@ class MaintenanceOff extends MooshCommand
 
     public function execute()
     {
-        set_config('maintenance_mesage', '');
+        set_config('maintenance_message', '');
         set_config('maintenance_enabled', 0);
         echo "Maintenance Mode Disabled\n";
     }


### PR DESCRIPTION
There was an typo in the set_config('maintenance_mesage', ''); line