### PR TITLE
Parses activity-specific options passed in, for example, --o "--intro=\"2 emails\" --course=33 --subnet=192.168.2.2"

### DIFF
--- a/Moosh/Command/Moodle26/Activity/ActivityAdd.php
+++ b/Moosh/Command/Moodle26/Activity/ActivityAdd.php
@@ -10,6 +10,8 @@
 namespace Moosh\Command\Moodle26\Activity;
 use Moosh\MooshCommand;
 
+use GetOptionKit\Argument;
+
 /**
  * Adds a new activity to the specified course
  *
@@ -58,6 +60,19 @@ class ActivityAdd extends MooshCommand
 
         // $options are course module options.
         $options = $this->expandedOptions;
+
+        if (!empty($options['options'])) {
+            $course_module_options = preg_split( '/\s+(?=--)/', $options['options']);
+            foreach ( $course_module_options as $option ) {
+                $arg = new Argument( $option );
+                $name = $arg->getOptionName();
+                $value = $arg->getOptionValue();
+                $moduledata->$name = $value;
+                if ($this->verbose) {
+                    echo "\"$option\" -> $name=" . $value . "\n";
+                }
+            }
+        }
 
         if (!empty($options['name'])) {
             $moduledata->name = $options['name'];

--- a/Moosh/Command/Moodle26/Activity/ActivityAdd.php
+++ b/Moosh/Command/Moodle26/Activity/ActivityAdd.php
@@ -28,6 +28,7 @@ class ActivityAdd extends MooshCommand
         $this->addOption('n|name:', 'activity instance name');
         $this->addOption('s|section:', 'section number', '1');
         $this->addOption('i|idnumber:', 'idnumber', null);
+        $this->addOption('c|gradecat:', 'gradecategory id', null);
         $this->addOption('o|options:', 'any options that should be passed for activity creation', null);
 
         $this->addArgument('activitytype');

--- a/tests/commands/activity-add.sh
+++ b/tests/commands/activity-add.sh
@@ -13,6 +13,12 @@ if echo "SELECT * FROM mdl_forum WHERE name='forumtest1'"\
 else
   exit 1
 fi
-~                                                                                       
-~                                                                                       
-~                                                                    
+
+$MOOSHCMD activity-add activity-add -n 'more emails' -o="--intro=\"polite orders.\" --grade=3 --subnet=192.168.2.2" quiz 2
+
+if echo "SELECT * FROM mdl_quiz WHERE name='more emails' AND intro='polite orders' AND grade=3 AND subnet='192.168.2.2' AND course=2"\
+        | mysql -u "$DBUSER" -p"$DBPASSWORD" "$DBNAME"; then
+  exit 0
+else
+  exit 1
+fi

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -17,6 +17,7 @@ by it's id.
     moosh activity-add --section 3 forum 4
     moosh activity-add --name "General course forum" --section 2 forum 3
     moosh activity-add --name "Easy assignent" --section 2 --idnumber "ASD123" assign 2
+    moosh activity-add -n 'more emails' -o="--intro=\"polite orders.\" --grade=3 --subnet=192.168.2.2" quiz 33
 
 <span class="anchor" id="activity-delete"></span>
 <a class="command-name">activity-delete</a>


### PR DESCRIPTION
Only long options (--option=value) are supported.

As requested in, https://moodle.org/mod/forum/discuss.php?d=368091


