### PR TITLE
Add idnumber when importing categories

### DIFF
--- a/Moosh/Command/Moodle26/Category/CategoryImport.php
+++ b/Moosh/Command/Moodle26/Category/CategoryImport.php
@@ -78,6 +78,9 @@ class CategoryImport extends MooshCommand
             echo "Creating new category " . $attrs['NAME'] . " under $current\n";
             $category = new \stdClass();
             $category->name = $attrs['NAME'];
+            if(isset($attrs['IDNUMBER'])) {
+                $category->idnumber = $attrs['IDNUMBER'];
+            }            
             $category->parent = $current;
 
             $newcat = $this->create_category($category);


### PR DESCRIPTION
Command "category-import" only import category names and hierarchy but idnumber is included in the XML file obtained with "category-export".