### PR TITLE
update enrol functions to include start/end dates

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseEnrol.php
+++ b/Moosh/Command/Moodle23/Course/CourseEnrol.php
@@ -22,10 +22,10 @@ class CourseEnrol extends MooshCommand {
         $this->addOption('i|id', 'use numeric IDs instead of user name(s)');
         $this->addOption('s|shortname', 'use course short name instead of course ID as first argument');
         $this->addOption('r|role:', 'role short name');
+	$this->addOption('S|startdate:', 'any date php strtotime can parse');
+	$this->addOption('E|enddate:', 'any date php strtotime can parse, or duration in # of days');
 
         //possible other options
-        //duration
-        //startdate
         //recovergrades
 
         $this->addArgument('courseid');
@@ -73,10 +73,34 @@ class CourseEnrol extends MooshCommand {
             die("No manual enrolment plugin for the course\n");
         }
         $plugin = $plugins['manual'];
-
-        $today = time();
-        $today = make_timestamp(date('Y', $today), date('m', $today), date('d', $today), 0, 0, 0);
-
+	
+	$startdate = $options['startdate'] ? strtotime($options['startdate']) : time();
+	if ($startdate === false) {
+            cli_error('invalid start date');
+        }
+	$startdate = make_timestamp(date('Y', $startdate), date('m', $startdate), date('d', $startdate), date('H', $startdate), date('i', $startdate), date('s', $startdate));
+				
+	if($options['enddate']) {
+		if(strtotime($options['enddate'])) {
+			$enddate = strtotime($options['enddate']);
+			$enddate = make_timestamp(date('Y', $enddate), date('m', $enddate), date('d', $enddate), date('H', $enddate), date('i', $enddate), date('s', $enddate));
+		} else if(preg_match("/^[1-9]\d*$/", $options['enddate'])) {
+			$enddate = $startdate + ($options['enddate'] * 86400);
+		} else {
+			cli_error('invalid end date or duration');
+		}
+	} else {
+		$enddate = 0;
+	}
+		
+	if ($enddate === false) {
+		cli_error('invalid end date');
+	}
+		
+        if ($enddate != 0 && $enddate < $startdate) {
+            cli_error('end date date must be higher than start date');
+        }
+		
         array_shift($arguments);
         foreach ($arguments as $argument) {
             if ($options['id']) {
@@ -88,7 +112,7 @@ class CourseEnrol extends MooshCommand {
                 cli_problem("User '$user' not found");
                 continue;
             }
-            $plugin->enrol_user($instance, $user->id, $role->id, $today, 0);
+            $plugin->enrol_user($instance, $user->id, $role->id, $startdate, $enddate);
         }
     }
 


### PR DESCRIPTION
My first attempt at contributing to any git repository so hopefully I am doing this correctly!

My organization uses moosh to manage our Moodle and we will soon be needing to enrol users with start and end dates on their enrollments.  Moosh is not capable of doing this so I thought I could add it.  

I thought that having the ability to specify both a duration or an end time would be helpful so I have built in the ability for either option.