### PR TITLE
gradecat grade_category id option for activity-add

### DIFF
--- a/Moosh/Command/Moodle26/Activity/ActivityAdd.php
+++ b/Moosh/Command/Moodle26/Activity/ActivityAdd.php
@@ -26,6 +26,7 @@ class ActivityAdd extends MooshCommand
         $this->addOption('n|name:', 'activity instance name');
         $this->addOption('s|section:', 'section number', '1');
         $this->addOption('i|idnumber:', 'idnumber', null);
+        $this->addOption('c|gradecat:', 'gradecategory id', null);
         $this->addOption('o|options:', 'any options that should be passed for activity creation', null);
 
         $this->addArgument('activitytype');

--- a/Moosh/Command/Moodle26/Activity/ActivityAdd.php
+++ b/Moosh/Command/Moodle26/Activity/ActivityAdd.php
@@ -66,6 +66,9 @@ class ActivityAdd extends MooshCommand
         if (!empty($options['idnumber'])) {
             $moduledata->idnumber = $options['idnumber'];
         }
+        if (!empty($options['gradecat'])) {
+            $moduledata->gradecat = $options['gradecat'];
+        }
 
         $moduledata->section = $options['section'];
 


### PR DESCRIPTION
edit_module_post_actions, called from add_moduleinfo, called from create_instance sets up a grade item's categoryid from a 'gradecat' field in the moduleinfo record.

Having a grade category is a useful property for most (all?) activities on a production site.  And, omission of the option will just result in the same behavior as before, the grade category being Uncategorized.