### PR TITLE
Continue if hit an exception on one course

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseDelete.php
+++ b/Moosh/Command/Moodle23/Course/CourseDelete.php
@@ -36,7 +36,11 @@ class CourseDelete extends MooshCommand
             }
 
             if ($course instanceof \stdClass) {
-                delete_course($course);
+                try {
+                    delete_course($course);
+                } catch (Exception $e) {
+                    print get_class($e) . " thrown for courseid={$course->id} within the exception handler. Message: " . $e->getMessage() . " on line " . $e->getLine();
+                }
             } else {
                 print "Course not found\n";
             }


### PR DESCRIPTION
If a course/quiz/etc is corrupt and throws an exception, continue attempting to delete subsequent courses.