### PR TITLE
Output which course will be deleted

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseDelete.php
+++ b/Moosh/Command/Moodle23/Course/CourseDelete.php
@@ -37,6 +37,7 @@ class CourseDelete extends MooshCommand
 
             if ($course instanceof \stdClass) {
                 try {
+                    print "About to delete course id={$course->id}; shortname=${$course->shortname}; category id=${$course->category}";
                     delete_course($course);
                 } catch (Exception $e) {
                     print get_class($e) . " thrown for courseid={$course->id} within the exception handler. Message: " . $e->getMessage() . " on line " . $e->getLine();


### PR DESCRIPTION
The current output (from Moodle code) shows output like:
++ Deleted - Completion tracking ++
++ Deleted - Grades, Items, Categories ++
... 
but has no indication of which course this refers to.