### PR TITLE
filepath variable is not always set

### DIFF
--- a/Moosh/Command/Moodle23/File/FileUpload.php
+++ b/Moosh/Command/Moodle23/File/FileUpload.php
@@ -43,7 +43,6 @@ class FileUpload extends MooshCommand
         }
 
         if ($arguments[0][0] != '/') {
-            $filepath = $this->cwd . DIRECTORY_SEPARATOR .  DIRECTORY_SEPARATOR .$arguments[0];
             $arguments[0] = $this->cwd . DIRECTORY_SEPARATOR . $arguments[0];
         }
 
@@ -68,7 +67,7 @@ class FileUpload extends MooshCommand
         $filerecord->filename   = $filename;
 
         try {
-            $fp->create_file_from_pathname($filerecord, $filepath);
+            $fp->create_file_from_pathname($filerecord, $arguments[0]);
             echo "File uploaded successfully!\n";
         }
         catch (Exception $e) {


### PR DESCRIPTION
Getting this error when executing `moosh file-upload --filename=169.mbz /app/moodledata/backup.mdz`

```
Notice: Undefined variable: filepath in /app/vendor/tmuras/moosh/Moosh/Command/Moodle23/File/FileUpload.php on line 71
Default exception handler: Cannot read file. Either the file does not exist or there is a permission problem. Debug:
Error code: storedfilecannotread```

Looking at the code in `FileUpload.php` $filepath variable is only set when the specified file does not start with a leading forward slash. In addition, $arguments[0] is used to reference the filepath throughout the code so suggest its more consistent to just use that throughout.