### PR TITLE
Allow for ignoring warnings on course-restore

### DIFF
--- a/Moosh/Command/Moodle29/Course/CourseRestore.php
+++ b/Moosh/Command/Moodle29/Course/CourseRestore.php
@@ -23,7 +23,7 @@ class CourseRestore extends MooshCommand {
         $this->addOption('d|directory', 'restore from extracted directory (1st param) under tempdir/backup');
         $this->addOption('e|existing', 'restore into existing course, id provided instead of category_id');
         $this->addOption('o|overwrite', 'restore into existing course, overwrite current content, id provided instead of category_id');
-
+        $this->addOption('i|ignore-warnings', 'continue with restore if there are pre-check warnings');
     }
 
     public function execute() {
@@ -43,7 +43,7 @@ class CourseRestore extends MooshCommand {
             $options['existing'] = true;
         }
 
-            // Check if category is OK.
+        // Check if category is OK.
         if (!$options['existing']) {
             $category = $DB->get_record('course_categories', array('id' => $this->arguments[1]), '*', MUST_EXIST);
         } else {
@@ -167,7 +167,9 @@ class CourseRestore extends MooshCommand {
             $check = $rc->get_precheck_results();
             cli_problem("Restore pre-check failed!");
             var_dump($check);
-            die();
+            if (!$options['ignore-warnings'] || array_key_exists('errors',$check)) {
+                die();
+            }
         }
 
         if ($options['existing'] && $options['overwrite']) {

--- a/Moosh/Command/Moodle33/Course/CourseRestore.php
+++ b/Moosh/Command/Moodle33/Course/CourseRestore.php
@@ -23,7 +23,7 @@ class CourseRestore extends MooshCommand {
         $this->addOption('d|directory', 'restore from extracted directory (1st param) under tempdir/backup');
         $this->addOption('e|existing', 'restore into existing course, id provided instead of category_id');
         $this->addOption('o|overwrite', 'restore into existing course, overwrite current content, id provided instead of category_id');
-
+        $this->addOption('i|ignore-warnings', 'continue with restore if there are pre-check warnings');
     }
 
     public function execute() {
@@ -162,7 +162,9 @@ class CourseRestore extends MooshCommand {
             $check = $rc->get_precheck_results();
             cli_problem("Restore pre-check failed!");
             var_dump($check);
-            die();
+            if (!$options['ignore-warnings'] || array_key_exists('errors',$check)) {
+                die();
+            }
         }
 
         if ($options['existing'] && $options['overwrite']) {


### PR DESCRIPTION
The course restore precheck can generate warnings and errors.
Many of the warnings that get generated do not impede course restores. I
added a flag that allows for ignoring course-restore warnings.

Here is an example of a warning I was experiencing:
```
  'warnings' =>
  array(5) {
    [0] =>
    string(148) "The questions category "CNC New: Turning", originally at system/course category context in backup file, will be created at course context by restore"
    [1] =>
    string(193) "The questions category "CNC Turning Technology with BenchTurn 7000 (Imperial/Virtual)", originally at system/course category context in backup file, will be created at course context by restore"
    [2] =>
    string(195) "The questions category "CNC Milling Technology with the ProMill 8000 (Imperial/Virtual)", originally at system/course category context in backup file, will be created at course context by restore"
    [3] =>
    string(195) "The questions category "CNC Turning Technology with the ProTurn 9000 (Imperial/Virtual)", originally at system/course category context in backup file, will be created at course context by restore"
    [4] =>
    string(148) "The questions category "CNC New: Milling", originally at system/course category context in backup file, will be created at course context by restore"
  }


```
This is safe to ignore