### PR TITLE
fixes #265, encode ampersands when storing to xml

### DIFF
--- a/Moosh/Command/Moodle27/Theme/SettingsExport.php
+++ b/Moosh/Command/Moodle27/Theme/SettingsExport.php
@@ -82,7 +82,8 @@ class SettingsExport extends MooshCommand {
             foreach ($themesettings as $settingname => $settingvalue) {
                 if ($settingname == 'version') continue;
 
-                $element = $dom->createElement('setting', $settingvalue);
+                $element = $dom->createElement('setting');
+                $element->appendChild($dom->createTextNode($settingvalue));
                 $element->setAttribute('name', $settingname);
 
                 if ($settingvalue && $settingvalue[0] == '/' && strpos($settingvalue, '.') !== FALSE) {


### PR DESCRIPTION
createElement only escapes < and > for some reason.

https://www.php.net/manual/en/domdocument.createelement.php

