### PR TITLE
gradeitem-create

### DIFF
--- a/Moosh/Command/Moodle23/GradeItem/GradeItemCreate.php
+++ b/Moosh/Command/Moodle23/GradeItem/GradeItemCreate.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2012 onwards Tomasz Muras
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle23\GradeItem;
+use Moosh\MooshCommand;
+
+use GetOptionKit\Argument;
+
+class GradeItemCreate extends MooshCommand {
+    public function __construct() {
+
+        parent::__construct('create', 'gradeitem');
+
+        $this->addOption('t|itemtype:', 'mod/manual/"" etc', 'manual');
+        $this->addOption('n|itemname:', 'item name', 'Grade');
+        $this->addOption('m|grademax:', 'maximum grade', '100');
+        $this->addOption('g|gradetype:', 'grade type (0 = none, 1 = value, 2 = scale, 3 = text)', '1');
+        $this->addOption('c|calculation:', 'grade calculation from other items', null);
+        $this->addOption('o|options:', 'any other options that should be passed for grade item creation', null);
+
+        $this->addArgument('courseid');
+        $this->addArgument('categoryid');
+
+        $this->minArguments = 2;
+    }
+
+    public function execute() {
+        global $CFG, $DB;
+
+        require_once($CFG->libdir . '/grade/grade_item.php');
+        require_once($CFG->libdir . '/gradelib.php');
+
+
+        $itemdata = new \stdClass();
+        $itemdata->courseid = $this->arguments[0];
+        $itemdata->categoryid = $this->arguments[1];
+        ## $itemdata->itemtype = 'manual';
+
+        $options = $this->expandedOptions;
+
+        foreach ($options as $k => $v) {
+            if ($k == 'options' && !empty($v)) {
+                $item_options = preg_split( '/\s+(?=--)/', $v);
+                foreach ( $item_options as $option ) {
+                    $arg = new Argument( $option );
+                    $name = $this->getOptionName($arg);
+                    $value = $arg->getOptionValue();
+                    $itemdata->$name = $value;
+                }
+            }
+            else { $itemdata->$k = $v; }
+        }
+
+        // $params = NULL;
+
+        $grade_item = new \grade_item($itemdata, false);
+
+        if ($this->verbose) {
+            echo print_r($itemdata) . "\n";
+        }
+        $source = 'manual';
+        $grade_item->insert($source);
+
+        echo $grade_item->id . "\n";
+    }
+
+    private function getOptionName($arg)
+    {
+        if (preg_match('/^[-]+([_a-zA-Z0-9-]+)/', $arg->arg, $regs)) {
+            return $regs[1];
+        }
+    }
+}

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -155,6 +155,16 @@ CREATE TABLE perflog (
 );
 </code></pre>
 
+<span class="anchor" id="assign-dupe"></span>
+<a class="command-name">assign-dupe</a>
+---------------
+
+Check existence of same string in possibly multiple assignment submissions, reporting unix time created and modified, and first and last name.
+
+Example:
+
+    moosh assign-dupe -a 613 -f onlinetext -d 'suspicious string'
+
 <span class="anchor" id="audit-passwords"></span>
 <a class="command-name">audit-passwords</a>
 ---------------
@@ -1153,6 +1163,16 @@ Example:
 
     moosh gradecategory-list --hidden=yes --empty=yes --fields=id,parent,fullname courseid=26
 
+<span class="anchor" id="gradeitem-create"></span>
+<a class="command-name">gradeitem-create</a>
+---------------
+
+Creates grade items, with command-line options and courseid, gradecategoryid arguments.
+
+Example:
+
+    moosh gradeitem-create --itemname=Boost --grademax=3 --calculation='=max(3, [[point]]' -o '--aggregationcoef=1' 37 527
+
 <span class="anchor" id="gradeitem-list"></span>
 <a class="command-name">gradeitem-list</a>
 ---------------
@@ -1232,7 +1252,6 @@ Example:
 
     moosh grouping-create --description "grouping description" --id "grouping idnumber" groupingname courseid
 
-
 <span class="anchor" id="group-assigngrouping"></span>
 <a class="command-name">group-assigngrouping</a>
 -------------
@@ -1242,7 +1261,6 @@ Add a group to a grouping.
 Example:
 
     moosh group-assigngrouping -G groupingid groupid1 [groupid2] ...
-
 
 <span class="anchor" id="info"></span>
 <a class="command-name">info</a>

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -1171,7 +1171,7 @@ Creates grade items, with command-line options and courseid, gradecategoryid arg
 
 Example:
 
-    moosh gradeitem-create --itemname=Boost --grademax=3 --calculation='=max(3, [[point]]' -o '--aggregationcoef=1' 37 527
+    moosh gradeitem-create --itemname=Boost --grademax=3 --calculation='=max(3, ##gi5075##)' -o '--aggregationcoef=1' 37 527
 
 <span class="anchor" id="gradeitem-list"></span>
 <a class="command-name">gradeitem-list</a>

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -155,16 +155,6 @@ CREATE TABLE perflog (
 );
 </code></pre>
 
-<span class="anchor" id="assign-dupe"></span>
-<a class="command-name">assign-dupe</a>
----------------
-
-Check existence of same string in possibly multiple assignment submissions, reporting unix time created and modified, and first and last name.
-
-Example:
-
-    moosh assign-dupe -a 613 -f onlinetext -d 'suspicious string'
-
 <span class="anchor" id="audit-passwords"></span>
 <a class="command-name">audit-passwords</a>
 ---------------


### PR DESCRIPTION
From  the documentation:

Creates grade items, with command-line options and courseid, gradecategoryid arguments.

Example:

    moosh gradeitem-create --itemname=Boost --grademax=3 --calculation='=max(3, ##gi5075##)' -o '--aggregationcoef=1' 37 527

