### PR TITLE
Cannot redeclare cli_problem error

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -106,8 +106,10 @@ function home_dir() {
  * @param $text
  * @return void
  */
-function cli_problem($text) {
-    fwrite(STDERR, $text . "\n");
+if(!function_exists('cli_problem')) {
+    function cli_problem($text) {
+	fwrite(STDERR, $text . "\n");
+    }
 }
 
 /**


### PR DESCRIPTION
In new moodle version /lib/clilib.php,  have the function cli_problem($text) already declared. 
Same is declared in Moosh includes/functions.php,, resulting in 
Fatal error: Cannot redeclare cli_problem() (previously declared in /usr/share/moosh/includes/functions.php:109)

