### PR TITLE
activity-config-set command

### DIFF
--- a/Moosh/Command/Moodle23/Activity/ActivityConfigSet.php
+++ b/Moosh/Command/Moodle23/Activity/ActivityConfigSet.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2012 onwards Tomasz Muras
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle23\Activity;
+use Moosh\MooshCommand;
+
+class ActivityConfigSet extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('config-set', 'activity');
+
+        $this->addOption('s|sectionnumber:=number', 'sectionnumber', null);
+
+        $this->addArgument('mode');
+        $this->addArgument('id');
+        $this->addArgument('module');
+        $this->addArgument('setting');
+        $this->addArgument('value');
+
+        $this->minArguments = 5;
+    }
+
+    public function execute()
+    {
+        $mode = $this->arguments[0];
+        $id = $this->arguments[1];
+        $modulename = $this->arguments[2];
+        $setting = trim($this->arguments[3]);
+        $value = trim($this->arguments[4]);
+
+        $options = $this->expandedOptions;
+        $sectionnumber = $options['sectionnumber'];
+
+        switch ($this->arguments[0]) {
+            case 'activity':
+                if(!self::setActivitySetting($modulename, $id/* activityid */,$setting,$value)){
+                	// the setting was not applied, exit with a non-zero exit code
+                	cli_error('');
+                }
+                break;
+            case 'course':
+                //get all activities in the course
+                $our_mod_info = get_fast_modinfo($id/* courseid */)->get_instances_of($modulename);
+                $updatelist = array();
+                foreach ($our_mod_info as $instance => $mod) {
+                    if ( empty( $sectionnumber ) ) {
+                        $updatelist[] = $mod;
+                    }
+                    elseif ( !empty($sectionnumber) and $mod->sectionnum == $sectionnumber ) {
+                        $updatelist[] = $mod;
+                    }
+                }
+                $succeeded = 0;
+                $failed = 0;
+                foreach ($updatelist as $activity) {
+                    if(self::setActivitySetting($modulename,$activity->instance,$setting,$value)){
+                        $succeeded++;
+                    }else{
+                        $failed++;
+                    }
+                }
+                if($failed == 0){
+                    echo "OK - successfully modified $succeeded activities\n";
+                }else{
+                    echo "WARNING - failed to modify $failed activities (successfully modified $succeeded)\n";
+                }
+                break;
+        }
+
+    }
+
+    private function setActivitySetting($modulename,$activityid,$setting,$value) {
+        
+        global $DB;
+        
+        if ($DB->set_field($modulename,$setting,$value,array('id'=>$activityid))) {
+            echo "OK - Set $setting='$value' ($modulename activityid={$activityid})\n";
+            return true;
+        } else {
+            echo "ERROR - failed to set $setting='$value' ($modulename activityid={$activityid})\n";
+            return false;
+        }
+
+    }
+
+    protected function getArgumentsHelp()
+    {
+        return "\n\nARGUMENTS:\n\tactivity activityid module setting value\n\tOr...\n\tcourse courseid[all] module setting value";
+    }
+
+}

--- a/Moosh/Command/Moodle23/Activity/ActivityConfigSet.php
+++ b/Moosh/Command/Moodle23/Activity/ActivityConfigSet.php
@@ -91,7 +91,7 @@ class ActivityConfigSet extends MooshCommand
 
     protected function getArgumentsHelp()
     {
-        return "\n\nARGUMENTS:\n\tactivity activityid module setting value\n\tOr...\n\tcourse courseid[all] module setting value";
+        return "\n\nARGUMENTS:\n\tactivity activityid moduletype setting value\n\tOr...\n\tcourse courseid[all] moduletype setting value";
     }
 
 }

--- a/Moosh/Command/Moodle23/Activity/ActivityConfigSet.php
+++ b/Moosh/Command/Moodle23/Activity/ActivityConfigSet.php
@@ -40,8 +40,8 @@ class ActivityConfigSet extends MooshCommand
         switch ($this->arguments[0]) {
             case 'activity':
                 if(!self::setActivitySetting($modulename, $id/* activityid */,$setting,$value)){
-                	// the setting was not applied, exit with a non-zero exit code
-                	cli_error('');
+                    // the setting was not applied, exit with a non-zero exit code
+                    cli_error('');
                 }
                 break;
             case 'course':
@@ -76,9 +76,9 @@ class ActivityConfigSet extends MooshCommand
     }
 
     private function setActivitySetting($modulename,$activityid,$setting,$value) {
-        
+
         global $DB;
-        
+
         if ($DB->set_field($modulename,$setting,$value,array('id'=>$activityid))) {
             echo "OK - Set $setting='$value' ($modulename activityid={$activityid})\n";
             return true;

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -48,6 +48,25 @@ Deletes activity with given module id.
     moosh activity-delete 2
 
 
+<span class="anchor" id="activity-config-set"></span>
+<a class="command-name">activity-config-set</a>
+---------------
+
+Follows the course-config-set pattern, updating a field in the Moodle {$module} table, (NOT {course_modules} table!), for a single activity of a given module type, or for all activities of that type (or only those in one section (optional)) in a course.
+
+Example 1: set the name of a single URL resource with instance(!) id=151
+
+    moosh activity-config-set activity 151 url name "Examinee handbook"
+
+Example 2: set introformat to markdown in all forums in a course with id=41
+
+    moosh activity-config-set course 41 forum introformat 4
+
+Example 3: set reviewrightanswer to "After quiz closes" for quizzes in section number 2 in a course with id=45
+
+    moosh activity-config-set -s 2 course 45 quiz reviewrightanswer 65552
+
+
 <span class="anchor" id="admin-login"></span>
 <a class="command-name">admin-login</a>
 ---------------


### PR DESCRIPTION
Does the same kind of thing as course-config-set, setting fields in the database, but on activities (of a given type). Also, it is restrictable to activities in a section.

