### PR TITLE
feat: add support for cockroachdb

### DIFF
--- a/Moosh/Command/Moodle23/Sql/SqlCli.php
+++ b/Moosh/Command/Moodle23/Sql/SqlCli.php
@@ -42,6 +42,14 @@ class SqlCli extends MooshCommand
                 putenv("PGPASSWORD={$CFG->dbpass}");
                 $connstr = "psql -h {$CFG->dbhost} -U {$CFG->dbuser} {$portoption} {$CFG->dbname}";
                 break;
+            case 'cockroachdb':
+                $portoption = '';
+                if (!empty($CFG->dboptions['dbport'])) {
+                    $portoption = '--port ' . $CFG->dboptions['dbport'];
+                }
+                putenv("COCKROACH_USER={$CFG->dbuser}");
+                $connstr = "cockroach sql --insecure --host {$CFG->dbhost} {$portoption} -d {$CFG->dbname}";
+                break;
             default:
                 cli_error("Sorry, database type '$CFG->dbtype' is not supported yet.  Feel free to contribute!");
                 break;

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -1664,7 +1664,7 @@ Example 2: Prevent "manager" role to be set on course level
 sql-cli
 -------
 
-Open a connection to the Moodle DB using credentials in config.php. Currently supports PostgreSQL and MySQL.
+Open a connection to the Moodle DB using credentials in config.php. Currently supports PostgreSQL, Cockroachdb, and MySQL.
 
 Example:
 
@@ -1674,7 +1674,7 @@ Example:
 sql-dump
 --------
 
-Dump Moodle DB to sql file. Works for PostgreSQL and MySQL.
+Dump Moodle DB to sql file. Works for PostgreSQL, Cockroachdb, and MySQL.
 
 Example 1: dump database to backup.sql file
 


### PR DESCRIPTION
cockroachdb uses the same wire protocol as postgres.
This adds support for the CLI