### PR TITLE
Add recursive option on CategoryResortCourses.php re: #287

### DIFF
--- a/Moosh/Command/Moodle36/Category/CategoryResortCourses.php
+++ b/Moosh/Command/Moodle36/Category/CategoryResortCourses.php
@@ -12,34 +12,61 @@ use core_course_category;
 
 class CategoryResortCourses extends MooshCommand
 {
-    public function __construct()
-    {
+    public function __construct() {
         parent::__construct('resortcourses', 'category');
 
         $this->addArgument('category_id');
         $this->addArgument('sort');
 
+        $this->addOption('r|recursive', 'recursively sort any subcategories');
+        $this->addOption('n|nocatsort', 'do not sort categories, only courses');
+
         $this->maxArguments = 2;
     }
 
-    public function execute()
-    {
+    public function execute() {
         global $DB;
 
+        $options = $this->expandedOptions;
+        $nocatsort = $options['nocatsort'];
+
         list($categoryid, $sort) = $this->arguments;
-        if (!$cattosort = $DB->get_record('course_categories', array('id'=>$categoryid))) {
+        if (!$cattosort = $DB->get_record('course_categories', array('id' => $categoryid))) {
             cli_error("No category with id '$categoryid' found");
-        }
-        else {
-            $this->resortcourses_category($cattosort, $sort);
+        } else {
+            if (!$options['recursive']) {
+                $this->resortcourses_category($cattosort, $sort);
+            } else {
+                $this->resortcategory_recursive($cattosort, $sort, $nocatsort);
+            }
         }
     }
 
-    protected function resortcourses_category($category, $sort)
-    {        
+    protected function resortcategory_recursive($category, $sort, $nocatsort) {
+
+        $categorieslist = core_course_category::make_categories_list('moodle/category:manage');
+        $categoryids = array_keys($categorieslist);
+        $categories = core_course_category::get_many($categoryids);
+        unset($categorieslist);
+
+        foreach ($categories as $cat) {
+
+            // Don't sort categories if -n/--nocatsort given.
+            if (!$nocatsort) {
+                // Don't clean up here, we'll do it once we're all done.
+                \core_course\management\helper::action_category_resort_subcategories($cat, 'name', false);
+            }
+
+            // Don't clean up here, we'll do it once we're all done.
+            \core_course\management\helper::action_category_resort_courses($cat, $sort, false);
+        }
+
+        // Cleanup now that we're done.
+        core_course_category::resort_categories_cleanup(true);
+    }
+
+    protected function resortcourses_category($category, $sort) {
         $cat = core_course_category::get($category->id);
-        $cat->resort_categories_cleanup(true);
-        return $cat->resort_courses($sort);
+        return $cat->resort_courses($sort, true);
     }
-
 }


### PR DESCRIPTION
Add the -r / --recursive flag to CategoryResortCourses.php. The initial code by  @benyovszky  only sorts the courses in a single category. This flag will sort allow the user to sort this category's courses,
and continue recursively. 

I took most of the code from /course/management.php

I believe this is an enhancement re: #287 