### PR TITLE
Issue #224 - Add --newsitems to course-create

### DIFF
--- a/Moosh/Command/Moodle23/Course/CourseCreate.php
+++ b/Moosh/Command/Moodle23/Course/CourseCreate.php
@@ -11,8 +11,7 @@ use Moosh\MooshCommand;
 
 class CourseCreate extends MooshCommand
 {
-    public function __construct()
-    {
+    public function __construct() {
         parent::__construct('create', 'course');
 
         $this->addOption('c|category:', 'category id');
@@ -23,43 +22,55 @@ class CourseCreate extends MooshCommand
         $this->addOption('i|idnumber:', 'id number');
         $this->addOption('v|visible:', 'visible (y or n, by default created visible)');
         $this->addOption('r|reuse', 'do not create new course if it a matching one already exists', false);
+        $this->addOption('N|newsitems:', 'the number of newsitems');
 
         $this->addArgument('shortname');
 
         $this->maxArguments = 255;
     }
 
-    public function execute()
-    {
+    public function execute() {
         global $CFG;
 
-        require_once $CFG->dirroot . '/course/lib.php';
+        require_once($CFG->dirroot . '/course/lib.php');
 
         foreach ($this->arguments as $argument) {
+
             $this->expandOptionsManually(array($argument));
             $options = $this->expandedOptions;
+
             $course = new \stdClass();
             $course->fullname = $options['fullname'];
             $course->shortname = $argument;
             $course->description = $options['description'];
+            $course->idnumber = $options['idnumber'];
+
             $format = $options['format'];
-            if(!$format){
-            	$format = get_config('moodlecourse', 'format');
+            if (!$format) {
+                $format = get_config('moodlecourse', 'format');
             }
             $course->format = $format;
+
             $numsections = $options['numsections'];
-            if(!$numsections){
-            	$numsections = get_config('moodlecourse', 'numsections');
+            if (!$numsections) {
+                $numsections = get_config('moodlecourse', 'numsections');
             }
             $course->numsections = $numsections;
-            $course->idnumber = $options['idnumber'];
+
+            $newsitems = $options['newsitems'];
+            if (!$newsitems || $newsitems > 10 || $newsitems < 0) {
+                $newsitems = get_config('moodlecourse', 'newsitems');
+            }
+            $course->newsitems = $newsitems;
+
             $visible = strtolower($options['visible']);
-            if($visible == 'n' || $visible == 'no' ){
-            	$visible = 0;
-            }else{
-            	$visible = 1;
+            if ($visible == 'n' || $visible == 'no' ) {
+                $visible = 0;
+            } else {
+                $visible = 1;
             }
             $course->visible = $visible;
+
             $course->category = $options['category'];
             $course->summary = '';
             $course->summaryformat = FORMAT_HTML;
@@ -68,7 +79,7 @@ class CourseCreate extends MooshCommand
             if ($options['reuse'] && $existing = $this->find_course($course)) {
                 $newcourse = $existing;
             } else {
-                //either use API create_course
+                // Either use API create_course.
                 $newcourse = create_course($course);
             }
 
@@ -76,8 +87,7 @@ class CourseCreate extends MooshCommand
         }
     }
 
-    public function find_course($course)
-    {
+    public function find_course($course) {
         global $DB;
         $params = array('shortname' => $course->shortname);
         foreach (array('category', 'fullname', 'format', 'idnumber') as $param) {

--- a/www/_site/commands/index.html
+++ b/www/_site/commands/index.html
@@ -698,9 +698,9 @@ it will only show which content could possibly be cleaned up.</p>
 <pre><code>moosh course-create --category 1 --fullname "full course name" --description "course description" --idnumber "course idnumber" shortname
 </code></pre>
 
-<p>Example 3: Create new course with section format, number options</p>
+<p>Example 3: Create new course with section format, number sections and news items</p>
 
-<pre><code>moosh course-create --category 4 --format topics --numsections 2 test
+<pre><code>moosh course-create --category 4 --format topics --numsections 2 --newsitems 8 test
 </code></pre>
 
 <a name="course-delete"></a>

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -561,9 +561,9 @@ Example 2: Create new course
 
     moosh course-create --category 1 --fullname "full course name" --description "course description" --idnumber "course idnumber" shortname
 
-Example 3: Create new course with section format, number options
+Example 3: Create new course with section format, number sections and news items
 
-    moosh course-create --category 4 --format topics --numsections 2 test
+    moosh course-create --category 4 --format topics --numsections 2 --newsitems 8 test
 
 
 course-delete


### PR DESCRIPTION
This adds `-N` or `--newsitems` to `course-create`.

If a value < 0 or > 10 is given, reverts to course default settings.

Attempted to update the docs to reflect this change.

Also some miscellaneous code format change to match up with Moodle
style guidelines and added whitespace to improve readability. Hope that's ok.