### PR TITLE
Fix download-moodle - Issue #324

### DIFF
--- a/Moosh/Command/Generic/Download/DownloadMoodle.php
+++ b/Moosh/Command/Generic/Download/DownloadMoodle.php
@@ -27,40 +27,48 @@ class DownloadMoodle extends MooshCommand {
         $options = $this->expandedOptions;
 
         // Example URLs
+        // Change in 3.9 naming convention for most recent release, when no version given.
+        // Changed from moodle-latest-38.tgz -> moodle-3.9.tgz (no 'latest', extra period).
+        // It appears the most recent release can't be "fetched" if specified with -v <major>.<minor>
+        //
         // Latest 3.4: https://download.moodle.org/download.php/direct/stable34/moodle-latest-34.tgz
         // 3.4.1:      https://download.moodle.org/download.php/direct/stable34/moodle-3.4.1.tgz
         // 3.4.0:      https://download.moodle.org/download.php/direct/stable34/moodle-3.4.tgz
         // Latest 3.3: https://download.moodle.org/download.php/direct/stable33/moodle-latest-33.tgz
 
-
-        if(!$options['version']) {
+        if (!$options['version']) {
             $releasepage = file_get_contents('https://download.moodle.org/releases/latest/');
-            preg_match('(https:\/\/download.moodle.org\/download.php\/stable[0-9].\/moodle-latest-[0-9].\.tgz)', $releasepage, $downloadurl);
+            preg_match('(https:\/\/download.moodle.org\/download.php\/stable[0-9].\/moodle-[0-9]\.[0-9]\.tgz)',
+                $releasepage, $downloadurl);
             $downloadpage = file_get_contents($downloadurl[0]);
-            preg_match('(\/download\.php\/direct\/stable[0-9].\/moodle-latest-[0-9].\.tgz)', $downloadpage, $downloadurl);
+            preg_match('(\/download\.php\/direct\/stable[0-9].\/moodle-[0-9]\.[0-9]\.tgz)', $downloadpage, $downloadurl);
             $url = 'https://download.moodle.org' . $downloadurl[0];
             run_external_command("wget --continue --timestamping '$url'", "Fetching file failed");
             die();
         }
 
         $version = explode('.', $options['version']);
-        if(count($version) == 3) {
+        if (count($version) == 3) {
             $major = $version[0];
             $minor = $version[1];
             $point = $version[2];
         } else if (count($version) == 2) {
             $major = $version[0];
             $minor = $version[1];
-            $point = -1; // Latest $major.$minor
-         } else {
+            $point = -1; // Latest $major.$minor.
+        } else {
             die("Provide version in X.Y or X.Y.Z format");
-         }
+        }
 
         $url = str_replace('<version>', $major . $minor, self::downloadUrl);
-        $url = str_replace('<major>', $major, $url);
-        $url = str_replace('<minor>', $minor, $url);
-        if($point != -1) {
-          $url = str_replace('<point>', $point, $url);
+        if ($point != -1) {
+            $url = str_replace('<major>', $major, $url);
+            $url = str_replace('<minor>', $minor, $url);
+            $url = str_replace('<point>', $point, $url);
+        } else {
+            // If no point release given, assume latest for that major.minor.
+            $url = str_replace('<major>.<minor>', 'latest-' . $major . $minor, $url);
+            $url = str_replace('<point>.', '', $url);
         }
 
         run_external_command("wget --continue --timestamping '$url'", "Fetching file failed");


### PR DESCRIPTION
This addresses Issue #324. It appears that the naming convention changed for how Moodle stores files to be downloaded. I was not involved writing this initial code, but it's clear that the current code gives a 404 error.

Before, if the version wasn't given as an option, it downloaded the most recent release. That file was stored like `moodle-latest-38.tgz`

As of now (3.9), it looks like `moodle-latest-39.tgz` does not exist, but `moodle-3.9.tgz` is indeed the latest version.

Also made some change to this code if a point release wasn't given, it redirects to `moodle-latest-majorminor.tgz` that seems to work. I don't know how this worked before - I might be missing something.

Also made a few miscellaneous updates to help match Moodle code style guidelines.