### PR TITLE
Fixed require.jamiepratt/moodle-qtype_TEMPLATE is invalid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
       "type": "package",
       "package": {
         "version": "dev-master",
-        "name": "jamiepratt/moodle-qtype_TEMPLATE",
+        "name": "jamiepratt/moodle-qtype_template",
         "source": {
           "url": "https://github.com/jamiepratt/moodle-qtype_TEMPLATE",
           "type": "git",
@@ -229,7 +229,7 @@
     "twig/twig": "1.18.2",
     "moodlehq/moodle-mod_newmodule": "dev-master#e1f112be8842291259ece87de3000cd5f0e18711",
     "danielneis/moodle-block_newblock": "dev-master#1fc89fb0845ad282426140feeb6bc3653efd1d7f",
-    "jamiepratt/moodle-qtype_TEMPLATE": "dev-master",
+    "jamiepratt/moodle-qtype_template": "dev-master",
     "danielneis/moodle-gradereport_newgradereport": "dev-master#691f53a15de352c3fe25da03c001a97a76b18358",
     "moodlehq/moodle-local_wstemplate": "dev-master#add2ad0949e72f025c0aad36c4b822e8c6479d3b",
     "yetanotherape/diff-match-patch": "dev-master#0726dbb4e59e68574326821c174013cf6fdfe20e",


### PR DESCRIPTION
When the word TEMPLATE is all in uppercase, composer was generating a warning:

Deprecation warning: require.jamiepratt/moodle-qtype_TEMPLATE is invalid, it should not contain uppercase characters. Please use jamiepratt/moodle-qtype_template instead. Make sure you fix this as Composer 2.0 will error.

Now that Composer 2.0 is out, it causes an error:

[RuntimeException]
require.jamiepratt/moodle-qtype_TEMPLATE is invalid, it should not contain uppercase characters. Please use jamiepratt/moodle-qtype_template instead.  

Now changed to lowercase.