### PR TITLE
Fixes #302 theme settings export of relative urls

### DIFF
--- a/Moosh/Command/Moodle27/Theme/SettingsExport.php
+++ b/Moosh/Command/Moodle27/Theme/SettingsExport.php
@@ -103,6 +103,10 @@ class SettingsExport extends MooshCommand {
                                 $root->appendChild($element);
                             }
                         }
+                    } else {
+                        // The value of this setting looked like a filename, but no matching file was found.
+                        // Append as a standard setting value.
+                        $root->appendChild($element);
                     }
                 } else {
                     $root->appendChild($element);


### PR DESCRIPTION
Minor fix for problem when exporting relative urls like /mod/blah/view.php?id=3 in theme settings.