### PR TITLE
#358 Allow creating users without an existing admin

### DIFF
--- a/Moosh/Command/Moodle23/User/UserCreate.php
+++ b/Moosh/Command/Moodle23/User/UserCreate.php
@@ -88,4 +88,9 @@ class UserCreate extends MooshCommand
             echo "$newuserid\n";
         }
     }
+
+    public function bootstrapLevel()
+    {
+        return self::$BOOTSTRAP_FULL_NO_ADMIN_CHECK;
+    }
 }

--- a/Moosh/Command/Moodle23/User/UserDelete.php
+++ b/Moosh/Command/Moodle23/User/UserDelete.php
@@ -41,4 +41,9 @@ class UserDelete extends MooshCommand
             }
          }
     }
+
+    public function bootstrapLevel()
+    {
+        return self::$BOOTSTRAP_FULL_NO_ADMIN_CHECK;
+    }
 }

--- a/Moosh/Command/Moodle23/User/UserList.php
+++ b/Moosh/Command/Moodle23/User/UserList.php
@@ -122,4 +122,9 @@ class UserList extends MooshCommand {
             echo $to_print . "\n";
         }
     }
+
+    public function bootstrapLevel()
+    {
+        return self::$BOOTSTRAP_FULL_NO_ADMIN_CHECK;
+    }
 }

--- a/Moosh/Command/Moodle23/User/UserMod.php
+++ b/Moosh/Command/Moodle23/User/UserMod.php
@@ -88,4 +88,9 @@ class UserMod extends MooshCommand
             echo $DB->update_record('user',$user) . "\n";
         }
     }
+
+    public function bootstrapLevel()
+    {
+        return self::$BOOTSTRAP_FULL_NO_ADMIN_CHECK;
+    }
 }

--- a/Moosh/Command/Moodle25/User/UserMod.php
+++ b/Moosh/Command/Moodle25/User/UserMod.php
@@ -106,4 +106,9 @@ class UserMod extends MooshCommand
             echo $DB->update_record('user',$user) . "\n";
         }
     }
+
+    public function bootstrapLevel()
+    {
+        return self::$BOOTSTRAP_FULL_NO_ADMIN_CHECK;
+    }
 }

--- a/Moosh/Command/Moodle31/User/UserMod.php
+++ b/Moosh/Command/Moodle31/User/UserMod.php
@@ -117,4 +117,9 @@ class UserMod extends MooshCommand
             echo $DB->update_record('user',$user) . "\n";
         }
     }
+
+    public function bootstrapLevel()
+    {
+        return self::$BOOTSTRAP_FULL_NO_ADMIN_CHECK;
+    }
 }

--- a/Moosh/MooshCommand.php
+++ b/Moosh/MooshCommand.php
@@ -48,6 +48,11 @@ class MooshCommand {
     public static $BOOTSTRAP_DB_ONLY = 4;
 
     /**
+     * @var int set CLI_SCRIPT and include config.php, don't check for admin
+     */
+    public static $BOOTSTRAP_FULL_NO_ADMIN_CHECK = 5;
+
+    /**
      * @var \GetOptionKit\OptionSpecCollection
      */
     public $spec;

--- a/moosh.php
+++ b/moosh.php
@@ -281,7 +281,9 @@ If you're sure you know what you're doing, run moosh with -n flag to skip that t
     @ini_set('display_errors', '1');
 
 
-    if ($subcommand->bootstrapLevel() != MooshCommand::$BOOTSTRAP_CONFIG) {
+    if ($subcommand->bootstrapLevel() != MooshCommand::$BOOTSTRAP_CONFIG
+        && $subcommand->bootstrapLevel() != MooshCommand::$BOOTSTRAP_FULL_NO_ADMIN_CHECK
+    ) {
         // By default set up $USER to admin user.
         if ($app_options->has('user')) {
             $user = get_user_by_name($app_options['user']->value);


### PR DESCRIPTION
It is useful to create a new user via moosh, even there is currently no admin (mdl_users might be completely empty)

The commands work already in that way, just a new bootstrap level is introduced to allow the user commands without an admin user