### PR TITLE
update reference to moodle-tool_pluginskel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -209,22 +209,22 @@
     {
       "type": "package",
       "package": {
-        "version": "dev-master",
+        "version": "dev-main",
         "name": "mudrd8mz/moodle-tool_pluginskel",
         "source": {
           "url": "https://github.com/mudrd8mz/moodle-tool_pluginskel",
           "type": "git",
-          "reference": "master"
+          "reference": "main"
         },
         "dist": {
-          "url": "https://github.com/mudrd8mz/moodle-tool_pluginskel/archive/master.zip",
+          "url": "https://github.com/mudrd8mz/moodle-tool_pluginskel/archive/main.zip",
           "type": "zip"
         }
       }
     }
   ],
   "require": {
-    "mudrd8mz/moodle-tool_pluginskel":"dev-master",
+    "mudrd8mz/moodle-tool_pluginskel":"dev-main",
     "corneltek/getoptionkit": "dev-master#3fd84905bb13d713477f1356beac1f9f9367ddcf",
     "twig/twig": "1.18.2",
     "moodlehq/moodle-mod_newmodule": "dev-master#e1f112be8842291259ece87de3000cd5f0e18711",

--- a/composer.lock
+++ b/composer.lock
@@ -251,15 +251,15 @@
         },
         {
             "name": "mudrd8mz/moodle-tool_pluginskel",
-            "version": "dev-master",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mudrd8mz/moodle-tool_pluginskel",
-                "reference": "master"
+                "reference": "main"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/mudrd8mz/moodle-tool_pluginskel/archive/master.zip"
+                "url": "https://github.com/mudrd8mz/moodle-tool_pluginskel/archive/main.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
Updates git info for the `moodle-tool_pluginskel` dependency so it installs correctly.

Closes https://github.com/tmuras/moosh/issues/367