### PR TITLE
allow renaming of user with user-mod

### DIFF
--- a/Moosh/Command/Moodle39/User/UserMod.php
+++ b/Moosh/Command/Moodle39/User/UserMod.php
@@ -21,6 +21,7 @@ class UserMod extends MooshCommand
         $this->addOption('a|auth:', 'auth');
         $this->addOption('p|password:', 'password');
         $this->addOption('e|email:','email address');
+        $this->addOption('u|username:','username');
 
         $this->addOption('g|global', 'user(s) to be set as global admin.', false);
         $this->addOption('n|ignorepolicy', 'ignore password policy.', false);
@@ -94,6 +95,9 @@ class UserMod extends MooshCommand
             }
             if($this->parsedOptions->has('email')) {
                 $user->email = $this->parsedOptions['email']->value;
+            }
+            if($this->parsedOptions->has('username')) {
+                $user->username = $this->parsedOptions['username']->value;
             }
             if($this->parsedOptions->has('auth')) {
                 $user->auth = $this->parsedOptions['auth']->value;


### PR DESCRIPTION
This is a very naive implementation of this feature. I just looked at the Moodle database model [1] and did not see a problem at first glance. If this is a very bad idea because of moodle implementation details please feel free to correct me.

[1] https://www.examulator.com/er/output/tables/user.html