### PR TITLE
Do not require admincheck if not required

### DIFF
--- a/Moosh/Command/Moodle39/Dev/DevLangusage.php
+++ b/Moosh/Command/Moodle39/Dev/DevLangusage.php
@@ -381,4 +381,8 @@ CODE;
 
         return $files;
     }
+    
+    public function bootstrapLevel() {
+        return self::$BOOTSTRAP_FULL_NO_ADMIN_CHECK;
+    }
 }


### PR DESCRIPTION
With this change, moosh can be used together with moodle-plugin-ci to run the dev-langusage check as component of a CI run.

I've confirmed this to be working after running the moodle-plugin-ci with install command.
This will become part of our CI sequence later on.