### PR TITLE
Ensure configuration data is correctly XML escaped

### DIFF
--- a/Moosh/Command/Moodle39/Config/ConfigPluginexport.php
+++ b/Moosh/Command/Moodle39/Config/ConfigPluginexport.php
@@ -140,7 +140,8 @@ class ConfigPluginexport extends MooshCommand
             foreach ($config as $settingname => $settingvalue) {
                 if ($settingname == 'version') continue;
 
-                $element = $dom->createElement('setting', $settingvalue);
+                $element = $dom->createElement('setting');
+                $element->appendChild($dom->createTextNode($settingvalue));
                 $element->setAttribute('name', $settingname);
 
                 if ($settingvalue && $settingvalue[0] == '/' && strpos($settingvalue, '.') !== FALSE) {


### PR DESCRIPTION
When running config-plugin-export for a fresh installation of moodle
3.11 errors about unterminated entity references were reported:

```
  mmatblsi@ITMC-DEV-N01:/var/www/moodle$ sudo sudo -u www-data moosh config-plugin-export -o /tmp/config atto_equation
  PHP Warning:  DOMDocument::createElement(): unterminated entity reference  a_2 \ a_3 & a_4 \end{matrix} \right|
  \frac{a}{b+c}
  \vec{a}
  \binom {a} {b}
  {a \brack b}
  {a \brace b} in /usr/local/moosh-2022040300/Moosh/Command/Moodle39/Config/ConfigPluginexport.php on line 143

  Warning: DOMDocument::createElement(): unterminated entity reference  a_2 \ a_3 & a_4 \end{matrix} \right|
  \frac{a}{b+c}
  \vec{a}
  \binom {a} {b}
  {a \brack b}
  {a \brace b} in /usr/local/moosh-2022040300/Moosh/Command/Moodle39/Config/ConfigPluginexport.php on line 143
  Config exported to /tmp/config/atto_equation_config_1655450316.xml
  mmatblsi@ITMC-DEV-N01:/var/www/moodle$
```

Checking the output file the configuration value for librarygroup4 in
the output file it shows, that it is empty. This matches the
documentation for DOMDocument::createElement:

>   The value is used verbatim except that the < and > entity references
>   will escaped. Note that & has to be manually escaped; otherwise it is
>   regarded as starting an entity reference. Also " won't be escaped. 

This can be fixed by explicitly creating the text content with
DOMDocument::createTextNode as also indicated in the PHP documentation.