### PR TITLE
Add role import-export command

### DIFF
--- a/Moosh/Command/Moodle33/Role/RoleExport.php
+++ b/Moosh/Command/Moodle33/Role/RoleExport.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * moosh - Moodle Shell - RoleExport command
+ *
+ * This command should be used to export role definition to an XML file.
+ *
+ * @example This example will write XML contents to a specific file
+ *          $ php moosh.php role-export -f target_file.xml ROLENAME
+ *
+ * @example This example will output XML contents to stdout
+ *          $ php moosh.php role-export ROLENAME
+ *
+ * @example This example will output pretty printed XML contents to stdout
+ *          $ php moosh.php role-export --pretty ROLENAME
+ *
+ * @copyright  2012 onwards Tomasz Muras
+ * @author     Andrej Vitez <contact@andrejvitez.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle33\Role;
+
+use core_role_preset;
+use DOMDocument;
+use Moosh\MooshCommand;
+
+class RoleExport extends MooshCommand {
+    public function __construct() {
+        parent::__construct('export', 'role');
+
+        $this->addOption('f|file:', 'Output file path. If empty then output will be printed to stdout.');
+        $this->addOption('r|pretty', 'Output formatted XML with whitespaces.');
+        $this->addArgument('shortname');
+    }
+
+    public function execute() {
+        global $CFG, $DB;
+
+        $rolename = $this->arguments[0];
+        if (!$rolename) {
+            printf("Short rolename argument is mandatory");
+            exit(1);
+        }
+        $role = $DB->get_record('role', array('shortname' => $rolename));
+        if (!$role) {
+            echo "Role '" . $rolename . "' does not exists!\n";
+            exit(1);
+        }
+
+        $filepath = $this->parsedOptions->get('file');
+        if (!$filepath) {
+            printf("Invalid output path value '%s'\n", $filepath);
+            exit(1);
+        }
+
+        require_once($CFG->libdir . '/filelib.php');
+        $xml = core_role_preset::get_export_xml($role->id);
+
+        if ($this->parsedOptions->get('pretty')) {
+            $dom = new DOMDocument('1.0');
+            $dom->preserveWhiteSpace = true;
+            $dom->formatOutput = true;
+            $dom->loadXML($xml);
+            $xml = $dom->saveXML();
+        }
+
+        if ($filepath) {
+            if (false === file_put_contents($filepath, $xml)) {
+                printf("Could not save XML contents to file '%s'\n", $filepath);
+                exit(1);
+            }
+
+            exit(0);
+        }
+
+        echo $xml . PHP_EOL;
+    }
+}

--- a/Moosh/Command/Moodle33/Role/RoleExport.php
+++ b/Moosh/Command/Moodle33/Role/RoleExport.php
@@ -47,7 +47,7 @@ class RoleExport extends MooshCommand {
             exit(1);
         }
 
-        $filepath = $this->parsedOptions->get('file');
+        $filepath = $this->expandedOptions['file'];
         if (!$filepath) {
             printf("Invalid output path value '%s'\n", $filepath);
             exit(1);
@@ -56,7 +56,7 @@ class RoleExport extends MooshCommand {
         require_once($CFG->libdir . '/filelib.php');
         $xml = core_role_preset::get_export_xml($role->id);
 
-        if ($this->parsedOptions->get('pretty')) {
+        if ($this->expandedOptions['pretty']) {
             $dom = new DOMDocument('1.0');
             $dom->preserveWhiteSpace = true;
             $dom->formatOutput = true;

--- a/Moosh/Command/Moodle33/Role/RoleImport/core_role_define_role_table_advanced_extended.php
+++ b/Moosh/Command/Moodle33/Role/RoleImport/core_role_define_role_table_advanced_extended.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * moosh - Moodle Shell - RoleImport helper form.
+ *
+ * @copyright  2012 onwards Tomasz Muras
+ * @author     Andrej Vitez <contact@andrejvitez.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle33\Role\RoleImport;
+
+use core_role_define_role_table_advanced;
+
+class core_role_define_role_table_advanced_extended extends core_role_define_role_table_advanced {
+    /**
+     * Clear self reference keys for an existing role. Otherwise, a DML insert exception will occur because fo duplicate entries.
+     *
+     * @return void
+     */
+    public function clear_self_references() {
+        if (empty($this->roleid)) {
+            return;
+        }
+
+        $this->clear_self_reference_for_type('assign');
+        $this->clear_self_reference_for_type('override');
+        $this->clear_self_reference_for_type('switch');
+        $this->clear_self_reference_for_type('view');
+    }
+
+    public function mark_changed_permissions($xmldata) {
+        $this->changed = array();
+
+        foreach ($this->capabilities as $cap) {
+            if ($cap->locked || $this->skip_row($cap)) {
+                // The user is not allowed to change the permission for this capability.
+                continue;
+            }
+
+            $permission = array_key_exists($cap->name, $this->permissions) ? $this->permissions[$cap->name] : null;
+            if (null === $permission) {
+                $permission = array_key_exists($cap->name, $xmldata->permissions) ? $xmldata->permissions[$cap->name] : null;
+            }
+            if (null === $permission) {
+                // A permission was not specified in XML data or inherited by base role or archetype.
+                continue;
+            }
+
+            // If the permission has changed, update $this->permissions and
+            if (!array_key_exists($cap->name, $this->permissions) || $this->permissions[$cap->name] != $permission) {
+                $this->permissions[$cap->name] = $permission;
+            }
+
+            // Record the fact there is data to save. Here is too late to detect changes because parent class has already
+            // overwritten data based on base role, archetype or XML data so just mark all as changed.
+            $this->changed[] = $cap->name;
+        }
+    }
+
+    public function clear_self_reference_for_type($type) {
+        $wanted = $this->{'allow' . $type};
+        foreach ($wanted as $idx => $roleid) {
+            if ($roleid == -1) {
+                unset($this->{'allow' . $type}[$idx]);
+            }
+        }
+    }
+}

--- a/Moosh/Command/Moodle33/Role/Roleimport.php
+++ b/Moosh/Command/Moodle33/Role/Roleimport.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * moosh - Moodle Shell - RoleImport command
+ *
+ * This command should be used to import role definition from an XML file.
+ *
+ * @example This example will import XML contents from a specific file
+ *          $ php moosh.php role-import -f source_file.xml
+ *
+ * @example This example will import XML contents by reading STDIN.
+ *          $ php moosh.php role-import --stdin < source_file.xml
+ *
+ * @copyright  2012 onwards Tomasz Muras
+ * @author     Andrej Vitez <contact@andrejvitez.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle33\Role;
+
+use context_system;
+use core_role_preset;
+use DOMDocument;
+use Moosh\Command\Moodle33\Role\RoleImport\core_role_define_role_table_advanced_extended;
+use Moosh\MooshCommand;
+
+class Roleimport extends MooshCommand {
+    private const STATUS_ERROR = 1;
+
+    public function __construct() {
+        parent::__construct('import', 'role');
+        $this->addOption('f|file:', 'Input file path. If empty then STDIN will be read.');
+        $this->addOption('i|stdin:', 'Read data from STDIN');
+    }
+
+    public function execute() {
+        global $DB;
+        $xmlData = '';
+
+        if (!class_exists('DOMDocument') || !extension_loaded('dom') || !extension_loaded('libxml')) {
+            $this->exitError('PHP DOMDocument and libxml support is mandatory. Unable to continue.');
+        }
+
+        if ($filepath = $this->parsedOptions->get('file')) {
+            if (!is_readable($filepath) || false === ($xmlData = file_get_contents($filepath))) {
+                $this->exitError(sprintf("Could not read input XML file '%s'\n", $filepath));
+            }
+        } else if ($this->parsedOptions->get('stdin')) {
+            $xmlData = stream_get_contents(STDIN);
+        } else {
+            $this->exitError('You need to specify input file or use STDIN.');
+        }
+
+        if (!$xmlData) {
+            $this->exitError('Invalid or empty XML contents. Please check your input.');
+        }
+
+        if (!$this->parsedOptions->get('skip-validate')) {
+            $this->validateSchema($xmlData);
+            $this->output('XML file validated successfully.', true);
+        }
+
+        if (!strlen($xmlData) || !$importData = core_role_preset::parse_preset($xmlData)) {
+            $this->exitError('Unable to parse XML data');
+        }
+
+        $rolename = $importData['shortname'];
+        if ($rolename) {
+            $role = $DB->get_record('role', array('shortname' => $rolename));
+        }
+
+        $archetype = $importData['archetype'];
+        $archetypes = get_role_archetypes();
+        if (!isset($archetypes[$archetype])) {
+            $this->exitError(sprintf('XML data defines an unknown archetype \'%s\'.', $archetype));
+        }
+
+        $options = array(
+            'shortname' => 1,
+            'name' => 1,
+            'description' => 1,
+            'permissions' => 1,
+            'archetype' => 1,
+            'contextlevels' => 1,
+            'allowassign' => 1,
+            'allowoverride' => 1,
+            'allowswitch' => 1,
+            'allowview' => 1
+        );
+
+        $systemcontext = context_system::instance();
+        $definitiontable = new core_role_define_role_table_advanced_extended($systemcontext, isset($role->id) ? $role->id : 0);
+
+        if (!empty($role->id)) {
+            $this->output('Original role exists, preloading all original role data.', true);
+            $definitiontable->force_duplicate($role->id, $options);
+        } else if ($archetype) {
+            $this->output('Original role does not exist, but XML defines archetype which is applied to initialize default role values.',
+                true);
+            $definitiontable->force_archetype($archetype, $options);
+        } else {
+            $this->output('No original role or archetype is defined. Forcing all initial values.', true);
+            $definitiontable->force_duplicate(0, $options);
+        }
+
+        $definitiontable->force_preset($xmlData, $options);
+        $definitiontable->clear_self_references();
+        $definitiontable->mark_changed_permissions($importData);
+
+        if (!$definitiontable->is_submission_valid()) {
+            $this->exitError('Unable to continue, submission has unknown errors.');
+        }
+
+        $definitiontable->save_changes();
+        $tableroleid = $definitiontable->get_role_id();
+
+        if (isset($role->id)) {
+            $this->output(sprintf('Updated role \'%s\' (id: %d)', $rolename, $tableroleid), true);
+        } else {
+            $this->output(sprintf('Inserted new role \'%s\' (id: %d)', $rolename, $tableroleid), true);
+        }
+    }
+
+    private function exitError($message, $statusCode = self::STATUS_ERROR) {
+        $this->output($message);
+        exit($statusCode);
+    }
+
+    private function output($message, $verbose = false) {
+        if ($verbose && !$this->verbose) {
+            return;
+        }
+        print $message . PHP_EOL;
+    }
+
+    public function validateSchema($xmlData) {
+        global $CFG;
+
+        $dom = new DOMDocument('1.0', 'utf-8');
+        $xmlSchema = $CFG->dirroot . '/admin/roles/role_schema.xml';
+
+        if (!file_exists($xmlSchema)) {
+            $this->exitError(sprintf('Unable to load XSD schema file \'%s\'', $xmlSchema));
+        }
+
+        $dom->loadXML($xmlData, LIBXML_NOBLANKS);
+        if (!$dom->schemaValidate($xmlSchema)) {
+            $this->output('Failed to validate XML schema!' .
+                ($this->verbose ? '' : ' Enable verbosity to show validation errors.'));
+
+            if ($this->verbose) {
+                $errors = libxml_get_errors();
+                foreach ($errors as $error) {
+                    $this->output(sprintf("\tvalidation error %s in '%s' (line: %d): '%s'", $error->code, $error->file,
+                        $error->line, trim($error->message)));
+                }
+                libxml_clear_errors();
+            }
+        }
+    }
+}

--- a/Moosh/Command/Moodle33/Role/Roleimport.php
+++ b/Moosh/Command/Moodle33/Role/Roleimport.php
@@ -30,6 +30,7 @@ class Roleimport extends MooshCommand {
         parent::__construct('import', 'role');
         $this->addOption('f|file:', 'Input file path. If empty then STDIN will be read.');
         $this->addOption('i|stdin:', 'Read data from STDIN');
+        $this->addOption('s|skip-validate', 'Skip XSD schema validation of input XML contents.');
     }
 
     public function execute() {

--- a/Moosh/Command/Moodle33/Role/Roleimport.php
+++ b/Moosh/Command/Moodle33/Role/Roleimport.php
@@ -41,11 +41,11 @@ class Roleimport extends MooshCommand {
             $this->exitError('PHP DOMDocument and libxml support is mandatory. Unable to continue.');
         }
 
-        if ($filepath = $this->parsedOptions->get('file')) {
+        if ($filepath = $this->expandedOptions['file']) {
             if (!is_readable($filepath) || false === ($xmlData = file_get_contents($filepath))) {
                 $this->exitError(sprintf("Could not read input XML file '%s'\n", $filepath));
             }
-        } else if ($this->parsedOptions->get('stdin')) {
+        } else if ($this->expandedOptions['stdin']) {
             $xmlData = stream_get_contents(STDIN);
         } else {
             $this->exitError('You need to specify input file or use STDIN.');
@@ -55,7 +55,7 @@ class Roleimport extends MooshCommand {
             $this->exitError('Invalid or empty XML contents. Please check your input.');
         }
 
-        if (!$this->parsedOptions->get('skip-validate')) {
+        if (!$this->expandedOptions['skip-validate']) {
             $this->validateSchema($xmlData);
             $this->output('XML file validated successfully.', true);
         }

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -1908,6 +1908,40 @@ Example 2: Delete role id 10.
     moosh role-delete -i 10
 
 
+role-export
+-----------
+
+Export role data, including permissions, role overrides, allow view settings and other related data.
+
+Example 1: Export specific role data to a an output XML file.
+
+    moosh role-export -f target_file.xml ROLENAME
+
+Example 2: Export specific role data, generate output XML export and print to stdout.
+
+    moosh role-export ROLENAME
+Example 3: Format XML with whitespaces (pretty format) and output XML contents to stdout.
+
+    moosh role-export --pretty ROLENAME
+
+role-import
+-----------
+
+Import role data from an XML file that was produced either by role-export command or Moodle permissions UI. 
+
+Example 1: Import role from a specific XML file.
+
+    moosh role-import -f source_file.xml
+
+Example 2: Import role by reading XML data from STDIN.
+
+    moosh role-import --stdin < source_file.xml
+
+You can either load XML data from a file or from STDIN.
+If XML defines an existing rolename then this command will sync changes to an existing role.
+If role does not exist and archetype is defined this command will create a new role with archetype defaults and xml permissions.
+If neither role nor archetype exist the new role will be created with INHERITED permissions defaults.
+
 role-list
 ---------
 


### PR DESCRIPTION
### role-export

Export role data, including permissions, role overrides, allow view settings and other related data.

Example 1: Export specific role data to a an output XML file.

    moosh role-export -f target_file.xml ROLENAME

Example 2: Export specific role data, generate output XML export and print to stdout.

    moosh role-export ROLENAME

Example 3: Format XML with whitespaces (pretty format) and output XML contents to stdout.

    moosh role-export --pretty ROLENAME

### role-import

Import role data from an XML file that was produced either by role-export command or Moodle permissions UI. 

Example 1: Import role from a specific XML file.

    moosh role-import -f source_file.xml

Example 2: Import role by reading XML data from STDIN.

    moosh role-import --stdin < source_file.xml

You can either load XML data from a file or from STDIN.
If XML defines an existing rolename then this command will sync changes to an existing role.
If role does not exist and archetype is defined this command will create a new role with archetype defaults and xml permissions.
If neither role nor archetype exist the new role will be created with INHERITED permissions defaults.
