### PR TITLE
Fix role reset command to include allow_view role settings

### DIFF
--- a/Moosh/Command/Moodle39/Role/RoleReset.php
+++ b/Moosh/Command/Moodle39/Role/RoleReset.php
@@ -49,7 +49,7 @@ class RoleReset extends MooshCommand
                 'allowassign'   => 1,
                 'allowoverride' => 1,
                 'allowswitch'   => 1,
-                'permissions'   => 1);
+                'allowview'   => 1);
             $definitiontable = new \core_role_define_role_table_advanced($systemcontext, $roleid);
 
             // Add all permissions from definition file to $_POST, otherwise, they won't be applied.


### PR DESCRIPTION
Fix typo to include role allow_view settings when resetting the role settings.