### PR TITLE
Add user online command

### DIFF
--- a/Moosh/Command/Moodle39/User/UserOnline.php
+++ b/Moosh/Command/Moodle39/User/UserOnline.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This command show currently online user list.
+ * In a contrast to TOP command this command uses Fetcher API and queries user table
+ * instead of standard log store.
+ *
+ * @example `moosh user-online`
+ *
+ * @copyright  2012 onwards Tomasz Muras
+ * @author     Andrej Vitez <contact@andrejvitez.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\User;
+
+use block_online_users\fetcher;
+use Moosh\MooshCommand;
+
+class UserOnline extends MooshCommand {
+    public function __construct() {
+        parent::__construct('online', 'user');
+        $this->addOption('t|time:', 'Show users online in last N seconds. Default 15 sec.', 15);
+        $this->addOption('l|limit:', 'Show maximum number of users. If empty all users are fetched.', 0);
+        $this->addOption('e|hideheader', 'Print header with table column names.', false);
+    }
+
+    public function execute() {
+        $timetoshowusers = (int) $this->expandedOptions['time'];
+        $now = time();
+
+        $onlineusers = new fetcher(null, $now, $timetoshowusers, \context_system::instance());
+
+        $usercount = $onlineusers->count_users();
+        $userlimit = $this->expandedOptions['limit'];
+        $users = $onlineusers->get_users($userlimit);
+
+        if (!$this->expandedOptions['hideheader']) {
+            printf(sprintf("Maximum number of users in last %d sec: %d\n", $timetoshowusers, $usercount));
+            printf(sprintf("Last check: %s\n\n", date('Y-m-h H:i:s', $now)));
+
+            printf(" %-7s | %-15s | %-25s | %-30s | %-20s\n",
+                'ID',
+                'USERNAME',
+                'NAME',
+                'EMAIL',
+                'LASTACCESS'
+            );
+        }
+
+        foreach ($users as $user) {
+            printf(" %-7d | %-15s | %-25s | %-30s | %-20s\n",
+                $user->id,
+                $user->username,
+                $user->lastname . ' ' . $user->firstname,
+                $user->email,
+                isset($user->lastaccess) ? date('Y-m-s H:i:s', $user->lastaccess) : '-'
+            );
+        }
+
+        echo PHP_EOL;
+    }
+}

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -2077,7 +2077,25 @@ If combined with "watch" command, it will imitate the poor man's "top" utility.
 Example:
 
     watch moosh top
- 
+
+user-online
+---
+
+Display currently online users in a simple table. In a contrast to TOP command this command uses Fetcher API and queries user table instead of standard log store.
+Available options:
+
+| Option           | Description                                                   |
+|------------------|---------------------------------------------------------------|
+| -t, --time       | Show users online in last N seconds. Default 15 sec.          |
+| -l, --limit      | Show maximum number of users. If empty all users are fetched. |
+| -e, --hideheader | Print header with table column names.                         |
+
+Use linux "watch" command to refresh screen periodically.
+
+Example: Show online users in last 5 minutes and refresh list every 5 seconds.
+
+    watch moosh user-online -t 300
+
 user-assign-system-role
 -----------------------
 


### PR DESCRIPTION
Display currently online users in a simple table. In a contrast to TOP command this command uses Fetcher API and queries user table instead of standard log store.
Available options:

| Option           | Description                                                   |
|------------------|---------------------------------------------------------------|
| -t, --time       | Show users online in last N seconds. Default 15 sec.          |
| -l, --limit      | Show maximum number of users. If empty all users are fetched. |
| -e, --hideheader | Print header with table column names.                         |

Use linux "watch" command to refresh screen periodically.

Example: Show online users in last 5 minutes and refresh list every 5 seconds.

    watch moosh user-online -t 300