### PR TITLE
Fix SQL query which references table identifier without using a proper parameterised syntax

### DIFF
--- a/Moosh/Command/Moodle39/Report/DataStats.php
+++ b/Moosh/Command/Moodle39/Report/DataStats.php
@@ -34,7 +34,7 @@ class DataStats extends MooshCommand {
         $sql_query = "SELECT SUM(filesize) AS total FROM {files}";
         $all_files = $DB->get_record_sql($sql_query);
 
-        $sql = "SELECT SUM(filesize) AS total FROM (SELECT filesize FROM mdl_files GROUP BY contenthash,filesize) sizes ";
+        $sql = "SELECT SUM(filesize) AS total FROM (SELECT filesize FROM {files} GROUP BY contenthash,filesize) sizes ";
         $distinctfilestotal = $DB->get_record_sql($sql)->total;
 
         // TODO: get sizes of:


### PR DESCRIPTION
Fix small typo in SQL query which references table identifier without using a proper parameterised syntax.
The problem occurs on Moodle setups that use table prefix different than default `mdl_`.