### PR TITLE
Add proxy support to a group of plugin commands

### DIFF
--- a/Moosh/Command/Generic/Plugin/PluginInstall.php
+++ b/Moosh/Command/Generic/Plugin/PluginInstall.php
@@ -5,6 +5,7 @@
  * @copyright  2012 onwards Tomasz Muras
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author     Kacper Golewski <k.golewski@gmail.com>
+ * @author     Andrej Vitez <contact@andrejvitez.com>
  */
 
 namespace Moosh\Command\Generic\Plugin;
@@ -24,6 +25,7 @@ class PluginInstall extends MooshCommand
         $this->addOption('r|release:', 'Specify exact version to install e.g. 2019010700');
         $this->addOption('f|force', 'Force installation even if current Moodle version is unsupported.');
         $this->addOption('d|delete', 'If it already exists, automatically delete plugin before installing.');
+        $this->addOption('r|proxy:', 'Proxy URI scheme. Example: tcp://user:pass@host:port. You may also use env var http_proxy.');
     }
 
     private function init()
@@ -73,7 +75,10 @@ class PluginInstall extends MooshCommand
         }
 
         try {
-            file_put_contents($downloadedfile, file_get_contents($downloadurl));
+            file_put_contents(
+                $downloadedfile,
+                file_get_contents($downloadurl, false, PluginDownload::createProxyContext($this->expandedOptions))
+            );
         }
         catch (Exception $e) {
             die("Failed to download plugin from $downloadurl. " . $e . "\n");

--- a/Moosh/Command/Generic/Plugin/PluginList.php
+++ b/Moosh/Command/Generic/Plugin/PluginList.php
@@ -5,50 +5,50 @@
  * @copyright  2012 onwards Tomasz Muras
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author     Kacper Golewski <k.golewski@gmail.com>
+ * @author     Andrej Vitez <contact@andrejvitez.com>
  */
 
 namespace Moosh\Command\Generic\Plugin;
+
 use Moosh\MooshCommand;
 
-class PluginList extends MooshCommand
-{
+class PluginList extends MooshCommand {
     static $APIURL = "https://download.moodle.org/api/1.3/pluglist.php";
 
-    public function __construct()
-    {
+    public function __construct() {
         parent::__construct('list', 'plugin');
 
         $this->addOption('p|path:', 'path to plugins.json file', home_dir() . '/.moosh/plugins.json');
         $this->addOption('v|versions', 'display plugin versions instead of supported moodle versions');
         $this->addOption('n|name-only', 'display only the frankenstyle name');
+        $this->addOption('r|proxy:', 'Proxy URI scheme. Example: tcp://user:pass@host:port. You may also use env var http_proxy.');
     }
 
-    public function execute()
-    {
-
+    public function execute() {
         $filepath = $this->expandedOptions['path'];
 
-        $stat = NULL;
-        if(file_exists($filepath)) {
+        $stat = null;
+        if (file_exists($filepath)) {
             $stat = stat($filepath);
         }
-        if(!$stat || time() - $stat['mtime'] > 60*60*24 || !$stat['size']) {
+        if (!$stat || time() - $stat['mtime'] > 60 * 60 * 24 || !$stat['size']) {
             @unlink($filepath);
-            file_put_contents($filepath, fopen(self::$APIURL, 'r'));
+            file_put_contents($filepath, file_get_contents(self::$APIURL, false, $this->createProxyContext()));
         }
+
         $jsonfile = file_get_contents($filepath);
 
-        if($jsonfile === false) {
+        if ($jsonfile === false) {
             die("Can't read json file");
         }
 
         $data = json_decode($jsonfile);
-        if(!$data) {
+        if (!$data) {
             unlink($filepath);
             cli_error("Invalid JSON file, deleted $filepath. Run command again.");
         }
         $fulllist = array();
-        foreach($data->plugins as $k=>$plugin) {
+        foreach ($data->plugins as $k => $plugin) {
             $highestpluginversion = 0;
             if (!$plugin->component) {
                 continue;
@@ -59,7 +59,7 @@ class PluginList extends MooshCommand
                     $highestpluginversion = $version->version;
                     $fulllist[$plugin->component]['latestversion'] = $version;
 
-                    if($this->expandedOptions['versions']) {
+                    if ($this->expandedOptions['versions']) {
                         $fulllist[$plugin->component]['releases'][$version->version] = $version;
                     } else {
                         foreach ($version->supportedmoodles as $supportedmoodle) {
@@ -71,22 +71,51 @@ class PluginList extends MooshCommand
             $fulllist[$plugin->component]['url'] = $fulllist[$plugin->component]['latestversion']->downloadurl;
         }
 
-
         ksort($fulllist);
-        foreach($fulllist as $pluginname => $plugin) {
-            if($this->expandedOptions['name-only']) {
+        foreach ($fulllist as $pluginname => $plugin) {
+            if ($this->expandedOptions['name-only']) {
                 echo "$pluginname\n";
                 continue;
             }
             $versions = array_keys($plugin['releases']);
             sort($versions);
 
-            echo "$pluginname," .implode(",",$versions) . ",".$plugin['url'] ."\n";
+            echo "$pluginname," . implode(",", $versions) . "," . $plugin['url'] . "\n";
         }
     }
 
-    public function bootstrapLevel()
-    {
+    /**
+     * @return resource|null
+     */
+    private function createProxyContext() {
+        $proxyUrl = !empty($this->expandedOptions['proxy'])
+            ? $this->expandedOptions['proxy']
+            : (getenv('http_proxy') ? getenv('http_proxy') : (getenv('HTTP_PROXY') ?: null));
+
+        if (!$proxyUrl) {
+            return null;
+        }
+
+        $uriParts = parse_url($proxyUrl);
+        $httpConfig = [
+            'proxy' => sprintf(
+                '%s://%s%s',
+                $uriParts['scheme'] ?? 'tcp',
+                $uriParts['host'],
+                empty($uriParts['port']) ? '443' : ':' . $uriParts['port']
+            ),
+            'request_fulluri' => true,
+        ];
+
+        if (!empty($uriParts['user']) && !empty($uriParts['pass'])) {
+            $authEncoded = base64_encode($uriParts['user'] . ':' . $uriParts['pass']);
+            $httpConfig['header'] = 'Proxy-Authorization: Basic ' . $authEncoded;
+        }
+
+        return stream_context_create(['http' => $httpConfig]);
+    }
+
+    public function bootstrapLevel() {
         return self::$BOOTSTRAP_NONE;
     }
 

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -1719,7 +1719,8 @@ plugin-download
 
 Download plugin for a given Moodle version to current directory.
 Requires plugin short name, and optional Moodle version.
-You can obtain avalible plugins names by using `plugin-list -n' command
+You can obtain avalible plugins names by using `plugin-list -n' command.
+You may specify proxy server with command line option or define ENV variable http_proxy.
 
 Example 1: Download block_fastnav for moodle 3.9 into ./block_fastnav.zip
 
@@ -1738,6 +1739,7 @@ plugin-install
 --------------
 
 Download and install plugin. Requires plugin short name, and optional version. You can obtain those data by using `plugin-list -v' command.
+You may specify proxy server with command line option or define ENV variable http_proxy.
 
 Example 1: install a specific version
 
@@ -1752,6 +1754,7 @@ plugin-list
 -----------
 
 List Moodle plugins filtered on given query. Returns plugin full name, short name, available Moodle versions and short description.
+You may specify proxy server with command line option or define ENV variable http_proxy.
 
 Example 1: list all plugins available on https://moodle.org/plugins
 


### PR DESCRIPTION
Add new command line option to specify proxy server to be used while communicating with Moodle plugin repository.
Instead of command line option a user may define environment variable http_proxy or HTTP_PROXY.