### PR TITLE
Allow specifying custom question format when importing question banks

### DIFF
--- a/Moosh/Command/Moodle40/Question/QuestionbankImport.php
+++ b/Moosh/Command/Moodle40/Question/QuestionbankImport.php
@@ -18,7 +18,7 @@ class QuestionbankImport extends MooshCommand
 
         $this->addArgument('questions.xml|questions.gift');
         $this->addArgument('question category ID');
-
+        $this->addArgument('question format', required: false);
     }
 
     public function execute()
@@ -37,12 +37,21 @@ class QuestionbankImport extends MooshCommand
         $fullpath = $this->checkPathArg($this->arguments[0]);
         $file = basename($fullpath);
 
-        if (substr($file, -4) == '.xml') {
-            $format = 'xml';
-        } else if (substr($file, -5) == '.gift') {
-            $format = 'gift';
+        if ($this->arguments[2] ?? false) {
+            $formatpath = $this->checkDirArg($CFG->dirroot . '/question/format/' . (string)$this->arguments[2]);
+            $format = basename($formatpath);
         } else {
-            cli_error("Unknown format. File extension should be .xml or .gift.");
+            $format = null;
+        }
+
+        if (!$format) {
+            if (substr($file, -4) == '.xml') {
+                $format = 'xml';
+            } else if (substr($file, -5) == '.gift') {
+                $format = 'gift';
+            } else {
+                cli_error("Unknown format. File extension should be .xml or .gift.");
+            }
         }
 
         $categoryid = (int)$this->arguments[1];

--- a/Moosh/MooshCommand.php
+++ b/Moosh/MooshCommand.php
@@ -177,9 +177,14 @@ class MooshCommand {
      *
      * @param string $name
      */
-    public function addArgument($name, $type = ARG_GENERIC) {
-        $this->minArguments++;
-        $this->maxArguments++;
+    public function addArgument($name, $type = ARG_GENERIC, $required=true) {
+        if ($required) {
+            $this->minArguments++;
+            $this->maxArguments++;
+        } else {
+            $this->maxArguments++;
+        }
+
         $this->argumentNames[] = $name;
 
         if ($type == ARG_EXISTING_FILENAME) {


### PR DESCRIPTION
Added optional parameter for questionbank-import command

i.e. `moosh -n -p MOODLE -u USER questionbank-import XML_FILE CATEGORY_ID canvas`
allows me to import question banks exported from Canvas using this plugin (https://github.com/jmvedrine/moodle-qformat_canvas)

Please let me know if it breaks compatibility.