### PR TITLE
fix: config-plugin-import builds additional file paths incorrectly

### DIFF
--- a/Moosh/Command/Moodle39/Config/ConfigPluginimport.php
+++ b/Moosh/Command/Moodle39/Config/ConfigPluginimport.php
@@ -140,8 +140,7 @@ class ConfigPluginimport extends MooshCommand {
                         $fs->delete_area_files($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], 0);
                     }
 
-                    $filepath = $this->inputfilepath.$setting->getAttribute('file');
-                    $fs->create_file_from_pathname($fileinfo, $filepath);
+                    $fs->create_file_from_pathname($fileinfo, $this->inputfilepath);
                 }
 
                 $todb = new stdClass;


### PR DESCRIPTION
Explained in this issue: <https://github.com/tmuras/moosh/issues/456>

`$this->inputfilepath` contains the entire path

while `$setting->getAttribute('file')` contains the hash