### PR TITLE
1 bugfix, 1 new --option and 1 new command

### DIFF
--- a/Moosh/Command/Moodle39/Activity/ActivityBackup.php
+++ b/Moosh/Command/Moodle39/Activity/ActivityBackup.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2024 fireartist
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Activity;
+use Moosh\MooshCommand;
+use backup_controller;
+use backup;
+
+class ActivityBackup extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('backup', 'activity');
+
+        $this->addOption('f|filename:', 'path to filename to save the activity backup');
+        $this->addOption('p|path:', 'path to save the activity backup');
+        $this->addOption('F|fullbackup', 'do full backup instead of general');
+        $this->addOption('template', 'do template backup instead of general');
+
+        $this->addArgument('cmid');
+    }
+
+    public function execute()
+    {
+        global $CFG, $DB, $USER;
+
+        require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
+
+        //check if course_moudule id exists
+        $cm = $DB->get_record('course_modules', array('id' => $this->arguments[0]), '*', MUST_EXIST);
+        $module = $DB->get_record('modules', array('id' => $cm->module), '*', MUST_EXIST);
+
+        $options = $this->expandedOptions;
+
+        $cwd=$this->cwd;
+        if (trim($options['path'])!="") {
+            $cwd=$options['path'];
+        }
+
+        if (!$options['filename']) {
+            $options['filename'] = $cwd . '/backup_activity-' . $this->arguments[0] . "-" . $module->name . $this->arguments[0] . '_' . date('Y.m.d') . '.mbz';
+        } elseif ($options['filename'][0] != '/') {
+            $options['filename'] = $cwd .'/' .$options['filename'];
+        }
+
+        //check if destination file does not exist and can be created
+        if (file_exists($options['filename'])) {
+            cli_error("File '{$options['filename']}' already exists, I will not over-write it.");
+        }
+
+        $bc = new backup_controller(\backup::TYPE_1ACTIVITY, $this->arguments[0], backup::FORMAT_MOODLE,
+        backup::INTERACTIVE_YES, backup::MODE_GENERAL, $USER->id);
+
+        if ($options['fullbackup']) {
+            $tasks = $bc->get_plan()->get_tasks();
+            foreach ($tasks as &$task) {
+                if ($task instanceof \backup_root_task) {
+                    $setting = $task->get_setting('logs');
+                    $setting->set_value('1');
+                    $setting = $task->get_setting('grade_histories');
+                    $setting->set_value('1');
+                }
+            }
+            unset($task);
+        }
+
+        if ($options['template']) {
+            $tasks = $bc->get_plan()->get_tasks();
+            foreach ($tasks as &$task) {
+                if ($task instanceof \backup_root_task) {
+                    $setting = $task->get_setting('users');
+                    $setting->set_value('0');
+                    $setting = $task->get_setting('anonymize');
+                    $setting->set_value('1');
+                    $setting = $task->get_setting('role_assignments');
+                    $setting->set_value('0');
+                    $setting = $task->get_setting('filters');
+                    $setting->set_value('0');
+                    $setting = $task->get_setting('comments');
+                    $setting->set_value('0');
+                    $setting = $task->get_setting('logs');
+                    $setting->set_value('0');
+                    $setting = $task->get_setting('grade_histories');
+                    $setting->set_value('0');
+                }
+            }
+            unset($task);
+        }
+
+        $bc->set_status(backup::STATUS_AWAITING);
+        $bc->execute_plan();
+        $result = $bc->get_results();
+
+        if(isset($result['backup_destination']) && $result['backup_destination']) {
+            $file = $result['backup_destination'];
+            /** @var $file stored_file */
+
+            if(!$file->copy_content_to($options['filename'])) {
+                cli_error("Problems copying final backup to '". $options['filename'] . "'");
+            } else {
+                printf("%s\n", $options['filename']);
+            }
+        } else {
+	    echo $bc->get_backupid();
+        }
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseBackup.php
+++ b/Moosh/Command/Moodle39/Course/CourseBackup.php
@@ -23,6 +23,7 @@ class CourseBackup extends MooshCommand
         $this->addOption('F|fullbackup', 'do full backup instead of general');
         $this->addOption('template', 'do template backup instead of general');
         $this->addOption('e|exclude:', 'comma-separated list of module names to exclude');
+        $this->addOption('excludecmid:=number', 'comma-separated list of module CMIDs to exclude');
 
         $this->addArgument('id');
         
@@ -82,6 +83,20 @@ class CourseBackup extends MooshCommand
                 if (is_subclass_of($task, 'backup_activity_task')) {
                     $modulename = $task->get_modulename();
                     if (in_array($modulename, $excludemodules)) {
+                        $setting = $task->get_setting('included');
+                        $setting->set_value('0');
+                    }
+                }
+            }
+        }
+
+        if ($options['excludecmid']) {
+            $excludecmids = explode(',', $options['excludecmid']);
+            $tasks = $bc->get_plan()->get_tasks();
+            foreach ($tasks as &$task) {
+                if (is_subclass_of($task, 'backup_activity_task')) {
+                    $cmid = $task->get_moduleid();
+                    if (in_array($cmid, $excludecmids)) {
                         $setting = $task->get_setting('included');
                         $setting->set_value('0');
                     }

--- a/Moosh/Command/Moodle39/Course/CourseBackup.php
+++ b/Moosh/Command/Moodle39/Course/CourseBackup.php
@@ -40,7 +40,7 @@ class CourseBackup extends MooshCommand
 
         $options = $this->expandedOptions;
 
-        if ($options['section']) {
+        if (strlen($options['section'])) {
             $section = $DB->get_record('course_sections', array('course' => $this->arguments[0], 'section' => $options['section']), '*', MUST_EXIST);
         }
 
@@ -50,7 +50,7 @@ class CourseBackup extends MooshCommand
         }
 
         if (!$options['filename']) {
-            if ($options['section']) {
+            if (strlen($options['section'])) {
                 // clean up the section name, remove invalid characters, etc. so we can use it in the filename
                 $sectionfilename = str_replace(' ','-',$section->name);
                 $sectionfilename = mb_ereg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $sectionfilename); $sectionfilename = mb_ereg_replace("([\.]{2,})", '', $sectionfilename);
@@ -67,7 +67,7 @@ class CourseBackup extends MooshCommand
             cli_error("File '{$options['filename']}' already exists, I will not over-write it.");
         }
 
-        if ($options['section']) {
+        if (strlen($options['section'])) {
             $bc = new backup_controller(\backup::TYPE_1SECTION, $section->id, backup::FORMAT_MOODLE,
             backup::INTERACTIVE_YES, backup::MODE_GENERAL, $USER->id);
         } else {

--- a/tests/commands/activity-backup.sh
+++ b/tests/commands/activity-backup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+source functions.sh
+
+install_db
+install_data
+cd $MOODLEDIR
+
+export BACKUP=/tmp/mooshactivitybackup.mbz
+rm -f $BACKUP
+$MOOSHCMD activity-backup -f $BACKUP 1
+if ls $BACKUP; then
+#  rm $BACKUP
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
Hi,
Would you consider accepting these changes?
I've tested the new `activity-backup` command on a live site, and successfully restored the backup file with the `course-restore` command.
I don't yet have an environment set up to allow running the test scripts - meaning I haven't run the new `activity-backup.sh` script which is based on your `course-backup.sh` - so I've put that in a separate commit in case you don't want to include it for now.
Do let me know if you'd prefer these to be broken out into separate pull-requests.