### PR TITLE
Accounting for non standard plugin packages when using plugin-install

### DIFF
--- a/Moosh/Command/Generic/Plugin/PluginInstall.php
+++ b/Moosh/Command/Generic/Plugin/PluginInstall.php
@@ -67,6 +67,8 @@ class PluginInstall extends MooshCommand
 
         if (!file_exists($tempdir)) {
             mkdir($tempdir);
+        } else {
+            run_external_command("rm -rf $tempdir/*");
         }
 
         if (!fopen($downloadedfile, 'w')) {
@@ -96,8 +98,12 @@ class PluginInstall extends MooshCommand
             }
         }
 
-        run_external_command("unzip $downloadedfile -d $installpath");
+        run_external_command("unzip $downloadedfile -d $tempdir");
         run_external_command("rm $downloadedfile");
+
+        //Get the path of uncompressed plugin dir (in case the .zip decompresses into multiple directories / non standard directory)
+        $uncompresseddir = exec("find $tempdir -name 'version.php' | rev | cut -d'/' -f 2- | rev");
+        run_external_command("mv $uncompresseddir $targetpath");
 
         echo "Installing\n";
         echo "\tname:    $pluginname\n";

--- a/Moosh/Command/Generic/Plugin/PluginInstall.php
+++ b/Moosh/Command/Generic/Plugin/PluginInstall.php
@@ -67,8 +67,6 @@ class PluginInstall extends MooshCommand
 
         if (!file_exists($tempdir)) {
             mkdir($tempdir);
-        } else {
-            run_external_command("rm -rf $tempdir/*");
         }
 
         if (!fopen($downloadedfile, 'w')) {
@@ -98,12 +96,22 @@ class PluginInstall extends MooshCommand
             }
         }
 
-        run_external_command("unzip $downloadedfile -d $tempdir");
+        $unzipdir = $tempdir . $component;
+        if (!file_exists($unzipdir)) {
+            mkdir($unzipdir);
+        }
+
+        run_external_command("unzip $downloadedfile -d $unzipdir");
         run_external_command("rm $downloadedfile");
 
         //Get the path of uncompressed plugin dir (in case the .zip decompresses into multiple directories / non standard directory)
-        $uncompresseddir = exec("find $tempdir -name 'version.php' | rev | cut -d'/' -f 2- | rev");
-        run_external_command("mv $uncompresseddir $targetpath");
+        $uncompresseddir = exec("find $unzipdir -name 'version.php' | rev | cut -d'/' -f 2- | rev");
+        if (file_exists($uncompresseddir)){
+            run_external_command("mv $uncompresseddir $targetpath");
+        } else {
+            die("The zipfile does not seem to be a valid plugin (no version.php found)\n");
+        }
+        run_external_command("rm -rf $unzipdir");
 
         echo "Installing\n";
         echo "\tname:    $pluginname\n";


### PR DESCRIPTION
Some plugins .zip file decompress in non standard directory (e.g. : zip file for atto_multilang2 decompresses into moodle-atto_multilang2-<version>; mod_hvp decompresses into 2 dir "hvp" and "__MACOSX")

I managed this by unpacking the zip file into the moosh tempdir, and then moving it to the right path with the correct dir name.

Tell me if there is anything wrong with these changes