### PR TITLE
New commands, couple of new features

### DIFF
--- a/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
+++ b/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
@@ -18,6 +18,12 @@ class CohortEnrol extends MooshCommand
         $this->addOption('c|courseid:', 'courseid');
         $this->addOption('idnumber', "Match cohort alphanumeric 'idnumber' field instead of name");
         $this->addOption('role:', "Defaults to 'student'", 'student');
+        $format_help = "Defaults to '%n_sync'. ";
+        $format_help .= "'%n' is replaced by cohort name, ";
+        $format_help .= "'%i' is replaced by cohort idnumber, ";
+        $format_help .= "'%r' is replaced by role name, ";
+        $format_help .= "'%s' is replaced by role shortname.";
+        $this->addOption('name-pattern:', $format_help, '%n_sync');
 
         $this->addArgument('name');
 
@@ -86,7 +92,7 @@ class CohortEnrol extends MooshCommand
                         $enrol = enrol_get_plugin('cohort');
 
                         $enrol->add_instance($course, array(
-                            'name'=>$argument . '_sync',
+                            'name'=>$this->build_sync_name($options['name-pattern'], $cohort, $role),
                             'status'=>0,
                             'customint1'=>$cohort->id,
                             'roleid'=>$role->id,
@@ -118,5 +124,15 @@ class CohortEnrol extends MooshCommand
         $trace = new \null_progress_trace();
         enrol_cohort_sync($trace, $courseid);
         $trace->finished();
+    }
+
+    protected function build_sync_name($pattern, $cohort, $role)
+    {
+        $pattern = preg_replace('/\%n/', $cohort->name, $pattern);
+        $pattern = preg_replace('/\%i/', $cohort->idnumber, $pattern);
+        $pattern = preg_replace('/\%r/', role_get_name($role), $pattern);
+        $pattern = preg_replace('/\%s/', $role->shortname, $pattern);
+
+        return $pattern;
     }
 }

--- a/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
+++ b/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
@@ -16,6 +16,7 @@ class CohortEnrol extends MooshCommand
 
         $this->addOption('u|userid:', 'userid');
         $this->addOption('c|courseid:', 'courseid');
+        $this->addOption('idnumber', "Match cohort alphanumeric 'idnumber' field instead of name");
 
         $this->addArgument('name');
 
@@ -35,7 +36,14 @@ class CohortEnrol extends MooshCommand
 
             // Sanity Checks.
             // Check if cohorst exists.
-            if (!$cohorts = $DB->get_records('cohort',array('name'=>$argument))) {
+            $cohort_search_params = [];
+            if ($options['idnumber']) {
+                $cohort_search_params['idnumber'] = $argument;
+            }
+            else {
+                $cohort_search_params['name'] = $argument;
+            }
+            if (!$cohorts = $DB->get_records('cohort', $cohort_search_params)) {
                 echo "Cohort does not exist\n";
                 exit(0);
             }

--- a/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
+++ b/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
@@ -17,6 +17,7 @@ class CohortEnrol extends MooshCommand
         $this->addOption('u|userid:', 'userid');
         $this->addOption('c|courseid:', 'courseid');
         $this->addOption('idnumber', "Match cohort alphanumeric 'idnumber' field instead of name");
+        $this->addOption('role:', "Defaults to 'student'", 'student');
 
         $this->addArgument('name');
 
@@ -33,6 +34,8 @@ class CohortEnrol extends MooshCommand
         foreach ($this->arguments as $argument) {
             $this->expandOptionsManually(array($argument));
             $options = $this->expandedOptions;
+
+            $role = $DB->get_record('role',array('shortname'=>$options['role']), '*', MUST_EXIST);
 
             // Sanity Checks.
             // Check if cohorst exists.
@@ -76,18 +79,17 @@ class CohortEnrol extends MooshCommand
                 foreach($cohorts as $cohort) {
 
                     // Check if cohort enrolment already exists
-                    if ($cohortenrolment = $DB->get_record('enrol',array('customint1'=>$cohort->id,'courseid'=>$options['courseid']))) {
+                    if ($cohortenrolment = $DB->get_record('enrol',array('customint1'=>$cohort->id,'courseid'=>$options['courseid'],'roleid'=>$role->id))) {
                         echo " Notice: Cohort already enrolled into course\n";
                     } else {
 
                         $enrol = enrol_get_plugin('cohort');
-                        $studentrole = $DB->get_record('role',array('shortname'=>'student'));
 
                         $enrol->add_instance($course, array(
                             'name'=>$argument . '_sync',
                             'status'=>0,
                             'customint1'=>$cohort->id,
-                            'roleid'=>$studentrole->id,
+                            'roleid'=>$role->id,
                             'customint2'=>'0'
                         ));
                         echo "Cohort enrolled\n";

--- a/Moosh/Command/Moodle39/Cohort/CohortUnSync.php
+++ b/Moosh/Command/Moodle39/Cohort/CohortUnSync.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2024 fireartist
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Cohort;
+use Moosh\MooshCommand;
+
+class CohortUnSync extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('unsync', 'cohort');
+
+        $this->addOption('idnumber', "Match cohort alphanumeric 'idnumber' field instead of name");
+        $this->addOption('role:', "Defaults to 'student'", 'student');
+
+        $this->addArgument('courseid');
+        $this->addArgument('cohortname');
+
+        $this->minArguments = 2;
+        $this->maxArguments = 2;
+    }
+
+    public function execute()
+    {
+        global $CFG, $DB, $PAGE;
+
+        require_once($CFG->dirroot . '/enrol/locallib.php');
+
+        list($courseid, $cohortname) = $this->arguments;
+        $options = $this->expandedOptions;
+
+        $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+
+        $cohort_search_params = [];
+        if ($options['idnumber']) {
+            $cohort_search_params['idnumber'] = $cohortname;
+        }
+        else {
+            $cohort_search_params['name'] = $cohortname;
+        }
+
+        $cohort = $DB->get_record('cohort', $cohort_search_params, '*', MUST_EXIST);
+
+        $role = $DB->get_record('role',array('shortname'=>$options['role']), '*', MUST_EXIST);
+
+        $manager = new \course_enrolment_manager($PAGE, $course);
+        $plugins = $manager->get_enrolment_plugins();
+        $enrolments = $manager->get_enrolment_instances();
+
+        foreach ($enrolments as $enrolment) {
+            if ($enrolment->enrol != "cohort") {
+                continue;
+            }
+            if ($enrolment->customint1 != $cohort->id) {
+                continue;
+            }
+            if ($enrolment->roleid != $role->id) {
+                continue;
+            }
+            $plugin = $plugins[$enrolment->enrol];
+            if (!isset($plugin)) {
+                continue;
+            }
+            $id = $enrolment->id;
+            $plugin->delete_instance($enrolment);
+            echo "Deleted enrolment instance [$id]\n";
+        }
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseAssignRole.php
+++ b/Moosh/Command/Moodle39/Course/CourseAssignRole.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2024 fireartist
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Course;
+
+use Moosh\MooshCommand;
+use course_enrolment_manager;
+
+class CourseAssignRole extends MooshCommand {
+
+    public function __construct() {
+        parent::__construct('assign-role', 'course');
+
+        $this->addOption('i|id', 'Use id to match a user');
+        $this->addOption('plugin:', "Enrol plugin (e.g. 'manual', 'self')", 'manual');
+
+        $this->addArgument('courseid');
+        $this->addArgument('role');
+        $this->addArgument('user');
+        $this->minArguments = 3;
+        $this->maxArguments = 255;
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "<role> must be the shortname, e.g. 'editingteacher', 'student'.\n";
+        $help .= "The user(s) must already be enrolled on the course with the selected --plugin.";
+
+        return $help;
+    }
+
+    public function execute() {
+        global $CFG, $DB, $PAGE;
+
+        require_once($CFG->dirroot . '/enrol/locallib.php');
+        require_once($CFG->dirroot . '/group/lib.php');
+
+        $options = $this->expandedOptions;
+        $users = $this->arguments;
+        $courseid = array_shift($users);
+        $rolename = array_shift($users);
+
+        $role = $DB->get_record('role', array('shortname' => $rolename), '*', MUST_EXIST);
+        if ($options['plugin'] == "manual") {
+            $component = "";
+        }
+        else {
+            $component = "enrol_" . $options['plugin'];
+        }
+        $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+        $manager = new course_enrolment_manager($PAGE, $course);
+
+        foreach ($users as $userid) {
+            if (!$options['id']) {
+                $userid = $DB->get_record('user',array('username'=>$userid), 'id', MUST_EXIST)->id;
+            }
+            $enrolments = $manager->get_user_enrolments($userid);
+            $ok = False;
+            foreach ($enrolments as $enrolment) {
+                list ($instance, $plugin) = $manager->get_user_enrolment_components($enrolment);
+                if ($instance->enrol != $options['plugin']) {
+                    continue;
+                }
+                role_assign(
+                    $role->id,
+                    $userid,
+                    \context_course::instance($course->id)->id,
+                    $component,
+                );
+                $ok = True;
+                break;
+            }
+            if (!$ok) {
+                printf("Did not find user enrolment of type '%s' for user '%d'\n", $options['plugin'], $userid);
+            }
+        }
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseDisableEnrolment.php
+++ b/Moosh/Command/Moodle39/Course/CourseDisableEnrolment.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2024 fireartist
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Course;
+use Moosh\MooshCommand;
+
+class CourseDisableEnrolment extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('disable-enrolment', 'course');
+
+        $this->addOption('r|role:', "User role (e.g. 'student', 'guest')", "student");
+        $this->addOption('n|norole', "Match enrolments with no role (set to zero)");
+        $this->addOption('c|cohort-name:', "Matched against either the Name (name) or Cohort ID (idnumber) - not the 'cohort.id' field.");
+
+        $this->addArgument('plugin');
+        $this->addArgument('courseid');
+
+        $this->maxArguments = 255;
+    }
+
+    public function execute()
+    {
+        global $CFG, $DB;
+
+        require_once $CFG->dirroot . '/course/lib.php';
+
+        $courseids = $this->arguments;
+        $plugintype = array_shift($courseids);
+
+        $options = $this->expandedOptions;
+        if ($options['role']) {
+            $role = $DB->get_record('role', array('shortname'=>$options['role']), '*', MUST_EXIST);
+
+            if (!$role) {
+                cli_error("--role did not match a role");
+            }
+        }
+
+        if ($options['cohort-name']) {
+            if ($plugintype != "cohort") {
+                cli_error("--cohort-name should only used with 'cohort' plugin-type");
+            }
+            $systemcontext = \context_system::instance();
+        }
+
+        foreach ($courseids as $courseid) {
+            // get the details for the course
+            $course = $DB->get_record('course', array('id'=>$courseid), '*', MUST_EXIST);
+
+            if ($options['cohort-name']) {
+                $catcontext = \context_coursecat::instance($course->category);
+
+                $str1 = $DB->sql_compare_text('name');
+                $str1ph = $DB->sql_compare_text(':name');
+                $str2 = $DB->sql_compare_text('idnumber');
+                $str2ph = $DB->sql_compare_text(':idnumber');
+
+                $cohort = $DB->get_records_sql(
+                    "SELECT * FROM {cohort} WHERE "
+                    ."( contextid = :systemcontext OR contextid = :catcontext ) "
+                    ."AND ({$str1} = {$str1ph} OR {$str2} = {$str2ph})",
+                    [
+                        'systemcontext' => $systemcontext->id,
+                        'catcontext' => $catcontext->id,
+                        'name' => $options['cohort-name'],
+                        'idnumber' => $options['cohort-name'],
+                    ]);
+
+                if (!$cohort) {
+                    cli_error("--cohort-name did not match a cohort");
+                }
+                if (count($cohort) > 1) {
+                    cli_error("--cohort-name matched more than 1 cohort");
+                }
+                list($cohort) = array_values($cohort);
+            }
+
+            // get the details of the enrolment plugin
+            $plugin = enrol_get_plugin($plugintype);
+            if(!$plugin){
+                cli_error("could not find '$plugintype' enrolment plugin");
+            }
+
+            // get the enrolment plugin instances for the course
+            $instances = enrol_get_instances($courseid, false);
+
+            // loop through the instances to find the instance ID for the enrolment plugin
+            $matchingInstances = [];
+            foreach($instances as $instance){
+                $match = False;
+                if ($instance->enrol === $plugintype){
+                    $match = True;
+                    if ($options['norole']) {
+                        if ($instance->roleid != 0) {
+                            $match = False;
+                        }
+                    }
+                    elseif ($options['role'] && $instance->roleid != $role->id) {
+                        $match = False;
+                    }
+
+                    if ($options['cohort-name'] && $instance->customint1 != $cohort->id){
+                        $match = False;
+                    }
+                }
+                if ($match) {
+                    $matchingInstances[] = $instance;
+                }
+            }
+
+            if ($matchingInstances) {
+                if(count($matchingInstances) == 1){
+                    $enrolInstance = $matchingInstances[0];
+                    // Deactivate enrolment
+                    if ($enrolInstance->status == ENROL_INSTANCE_ENABLED) {
+                        $plugin->update_status($enrolInstance, ENROL_INSTANCE_DISABLED);
+                    }
+                }
+                else {
+                    cli_error("enrolment plugin '$plugintype' matched more than 1 instance: "
+                        ."try using the --role or --cohort-name options to narrow the selection");
+                }
+            }
+        }
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseEnableguest.php
+++ b/Moosh/Command/Moodle39/Course/CourseEnableguest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2024 fireartist
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Course;
+use Moosh\MooshCommand;
+
+class CourseEnableguest extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('enableguest', 'course');
+
+        $this->addOption('k|key:', 'enrolment key - defaults to none');
+
+        $this->addArgument('id');
+
+        $this->maxArguments = 255;
+    }
+
+    public function execute()
+    {
+        global $CFG, $DB;
+
+        require_once $CFG->dirroot . '/course/lib.php';
+
+        foreach ($this->arguments as $courseid) {
+            $this->expandOptionsManually(array($courseid));
+            $options = $this->expandedOptions;
+
+            // get the details for the course
+            $course = $DB->get_record('course', array('id'=>$courseid), '*', MUST_EXIST);
+
+            // get the details of the guest enrolment plugin
+            $plugin = enrol_get_plugin('guest');
+            if(!$plugin){
+                cli_error('could not find guest enrolment plugin');
+            }
+
+            // get the enrolment plugin instances for the course
+            $instances = enrol_get_instances($courseid, false);
+
+            // loop through the instances to find the instance ID for the guest-enrolment plugin
+            $guestEnrolInstance = 0;
+            foreach($instances as $instance){
+                if($instance->enrol === 'guest'){
+                    $guestEnrolInstance = $instance;
+                    break;
+                }
+            }
+
+            // if we didn't find an instance for the guest enrolment plugin then we need to add
+            // one to the course
+            if(!$guestEnrolInstance){
+                // first try add an instance
+                $plugin->add_default_instance($course);
+
+                // then try retreive it
+                $instances = enrol_get_instances($courseid, false);
+                $guestEnrolInstance = 0;
+                foreach($instances as $instance){
+                    if($instance->enrol === 'guest'){
+                        $guestEnrolInstance = $instance;
+                        break;
+                    }
+                }
+
+                // if we still didn't get an instance - give up
+                if(!$guestEnrolInstance){
+                    cli_error('failed to create instance of guest enrolment plugin');
+                }
+            }
+
+            // activate self enrolment
+            if ($guestEnrolInstance->status != ENROL_INSTANCE_ENABLED) {
+                $plugin->update_status($guestEnrolInstance, ENROL_INSTANCE_ENABLED);
+            }
+
+            $plugin->update_instance($guestEnrolInstance, [
+                // set the enrolment key (always do this so running without the -k option will blank a pre-existing key)
+                'password' => $options['key'],
+                'status' => ENROL_INSTANCE_ENABLED,
+            ]);
+
+            // set the enrolment key (always do this so running without the -k option will blank a pre-existing key)
+            $instance_fromDB = $DB->get_record('enrol', array('courseid'=>$course->id, 'enrol'=>'guest', 'id'=>$guestEnrolInstance->id), '*', MUST_EXIST);
+            $instance_fromDB->password = $options['key'];
+            $DB->update_record('enrol', $instance_fromDB);
+        }
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseEnableselfenrol.php
+++ b/Moosh/Command/Moodle39/Course/CourseEnableselfenrol.php
@@ -49,6 +49,7 @@ class CourseEnableselfenrol extends MooshCommand
             foreach($instances as $instance){
                 if($instance->enrol === 'self'){
                     $selfEnrolInstance = $instance;
+                    break;
                 }
             }
             
@@ -64,6 +65,7 @@ class CourseEnableselfenrol extends MooshCommand
                 foreach($instances as $instance){
                     if($instance->enrol === 'self'){
                         $selfEnrolInstance = $instance;
+                        break;
                     }
                 }
                 

--- a/Moosh/Command/Moodle39/Course/CourseReorder.php
+++ b/Moosh/Command/Moodle39/Course/CourseReorder.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2024 fireartist
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Course;
+
+use Moosh\MooshCommand;
+use core_course_category;
+
+class CourseReorder extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('reorder', 'course');
+
+        $this->addOption('up', 'Move course 1 position up within its category');
+        $this->addOption('down', 'Move course 1 position down within its category');
+        $this->addOption('top', 'Move course to the top of the course list within its category');
+        $this->addOption('bottom', 'Move course to the bottom of the course list within its category');
+
+        $this->addArgument('id');
+        $this->minArguments = 1;
+        $this->maxArguments = 1;
+    }
+
+    public function execute()
+    {
+        global $DB;
+
+        $options = $this->expandedOptions;
+        $counts = array_count_values($options);
+
+        if ((!array_key_exists(1, $counts)) || $counts[1] != 1) {
+            cli_error("Must provide 1 of the following: --up, --down, --top, --bottom");
+        }
+
+        list($courseid) = $this->arguments;
+        $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+
+        $courses = $DB->get_records(
+            'course',
+            [
+                'category' => $course->category,
+            ],
+            'sortorder ASC',
+            'id, sortorder',
+        );
+        # reset index to be consecutive from zero
+        $courses = array_values($courses);
+
+        if ($options['up']) {
+            $this->move_up($courses, $courseid);
+        }
+        elseif ($options['top']) {
+            $this->move_top($courses, $courseid);
+        }
+        elseif ($options['down']) {
+            $this->move_down($courses, $courseid);
+        }
+        elseif ($options['bottom']) {
+            $this->move_bottom($courses, $courseid);
+        }
+
+        # Create event
+        $category = core_course_category::get($course->category);
+
+        $event = \core\event\course_category_updated::create([
+            'objectid' => $category->id,
+            'context' => $category->get_context()
+        ]);
+        $event->trigger();
+
+        # Clear cache
+        core_course_category::resort_categories_cleanup(true);
+
+        return true;
+    }
+
+    protected function move_up($courses, $id) {
+        global $DB;
+
+        if ($courses[0]->id == $id) {
+            # already at top
+            return;
+        }
+
+        # Set target to previous sortorder.
+        # Set 1-before-target to target's sortorder.
+
+        $prev = False;
+
+        foreach ($courses as $index => &$item) {
+            # Test for target before the +1 test, so we never go out of bounds.
+            if ($item->id == $id) {
+                $DB->set_field('course', 'sortorder', $prev, ['id' => $item->id]);
+                # We're only swapping 2 items, so can stop now.
+                break;
+            }
+            elseif ($courses[$index+1]->id == $id) {
+                $prev = $item->sortorder;
+                $DB->set_field('course', 'sortorder', $courses[$index+1]->sortorder, ['id' => $item->id]);
+            }
+        }
+    }
+
+    protected function move_top($courses, $id) {
+        global $DB;
+
+        if ($courses[0]->id == $id) {
+            # already at top
+            return;
+        }
+
+        # Set target to first sortorder.
+        # Set all items before target to next item's sortorder.
+
+        $first = $courses[0]->sortorder;
+
+        foreach ($courses as $index => &$item) {
+            if ($item->id == $id) {
+                $DB->set_field('course', 'sortorder', $first, ['id' => $item->id]);
+                # We don't edit any items *after* the target, so can stop now.
+                break;
+            }
+            else {
+                $DB->set_field('course', 'sortorder', $courses[$index+1]->sortorder, ['id' => $item->id]);
+            }
+        }
+    }
+
+    protected function move_down($courses, $id) {
+        global $DB;
+
+        if ($courses[count($courses)-1]->id == $id) {
+            # already at bottom
+            return;
+        }
+
+        # Set target to next it's sortorder.
+        # Set 1-after-target to target's sortorder.
+
+        $prev = False;
+
+        foreach ($courses as $index => &$item) {
+            if ($item->id == $id) {
+                $prev = $item->sortorder;
+                $DB->set_field('course', 'sortorder', $courses[$index+1]->sortorder, ['id' => $item->id]);
+            }
+            # Check it's not the first item in the list so we don't go out of bounds.
+            # The first item in the list is never going to the the item *after* the target.
+            elseif ($index != 0 && $courses[$index-1]->id == $id) {
+                $DB->set_field('course', 'sortorder', $prev, ['id' => $item->id]);
+                # We're only swapping 2 items, so can stop now.
+                break;
+            }
+        }
+    }
+
+    protected function move_bottom($courses, $id) {
+        global $DB;
+
+        if ($courses[count($courses)-1]->id == $id) {
+            # already at bottom
+            return;
+        }
+
+        # Ignore items until the target courseid (prev not set).
+        # Set target to last sortorder.
+        # Set subsequent items to the previous sortorder.
+
+        $prev = False;
+        $last = $courses[count($courses)-1]->sortorder;
+
+        foreach ($courses as $index => &$item) {
+            if ($item->id == $id) {
+                $prev = $item->sortorder;
+                $DB->set_field('course', 'sortorder', $last, ['id' => $item->id]);
+            }
+            elseif ($prev) {
+                $sortorder = $item->sortorder;
+                $DB->set_field('course', 'sortorder', $prev, ['id' => $item->id]);
+                $prev = $sortorder;
+            }
+        }
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseUnassignRole.php
+++ b/Moosh/Command/Moodle39/Course/CourseUnassignRole.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright  2024 fireartist
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Course;
+
+use Moosh\MooshCommand;
+use course_enrolment_manager;
+
+class CourseUnassignRole extends MooshCommand {
+
+    public function __construct() {
+        parent::__construct('unassign-role', 'course');
+
+        $this->addOption('i|id', 'Use id to match a user');
+        $this->addOption('plugin:', "Enrol plugin (e.g. 'manual', 'self')", 'manual');
+
+        $this->addArgument('courseid');
+        $this->addArgument('role');
+        $this->addArgument('user');
+        $this->minArguments = 3;
+        $this->maxArguments = 255;
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "The user(s) must already be enrolled on the course with the selected --plugin.";
+
+        return $help;
+    }
+
+    public function execute() {
+        global $CFG, $DB, $PAGE;
+
+        require_once($CFG->dirroot . '/enrol/locallib.php');
+        require_once($CFG->dirroot . '/group/lib.php');
+
+        $options = $this->expandedOptions;
+        $users = $this->arguments;
+        $courseid = array_shift($users);
+        $rolename = array_shift($users);
+
+        $role = $DB->get_record('role', array('shortname' => $rolename), '*', MUST_EXIST);
+        if ($options['plugin'] == "manual") {
+            $component = "";
+        }
+        else {
+            $component = "enrol_" . $options['plugin'];
+        }
+        $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+        $manager = new course_enrolment_manager($PAGE, $course);
+
+        foreach ($users as $userid) {
+            if (!$options['id']) {
+                $userid = $DB->get_record('user',array('username'=>$userid), 'id', MUST_EXIST)->id;
+            }
+            $enrolments = $manager->get_user_enrolments($userid);
+            $ok = False;
+            foreach ($enrolments as $enrolment) {
+                list ($instance, $plugin) = $manager->get_user_enrolment_components($enrolment);
+                if ($instance->enrol != $options['plugin']) {
+                    continue;
+                }
+                role_unassign(
+                    $role->id,
+                    $userid,
+                    \context_course::instance($course->id)->id,
+                    $component,
+                );
+                $ok = True;
+                break;
+            }
+            if (!$ok) {
+                printf("Did not find user enrolment of type '%s' for user '%d'\n", $options['plugin'], $userid);
+            }
+        }
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseUnenrol.php
+++ b/Moosh/Command/Moodle39/Course/CourseUnenrol.php
@@ -17,6 +17,8 @@ class CourseUnenrol extends MooshCommand {
     public function __construct() {
         parent::__construct('unenrol', 'course');
 
+        $this->addOption('p|plugin:', "Plugin type (e.g. 'manual')");
+
         $this->addArgument('courseid');
         $this->addArgument('userid');
         $this->minArguments = 2;
@@ -29,6 +31,7 @@ class CourseUnenrol extends MooshCommand {
         require_once($CFG->dirroot . '/enrol/locallib.php');
         require_once($CFG->dirroot . '/group/lib.php');
 
+        $options = $this->expandedOptions;
         $arguments = $this->arguments;
 
         $course = $DB->get_record('course', array('id' => $arguments[0]), '*', MUST_EXIST);
@@ -43,6 +46,9 @@ class CourseUnenrol extends MooshCommand {
             foreach ($enrolments as $enrolment) {
                 list ($instance, $plugin) = $manager->get_user_enrolment_components($enrolment);
                 if ($instance && $plugin && $plugin->allow_unenrol_user($instance, $enrolment)) {
+                    if ($options['plugin'] && $instance->enrol != $options['plugin']) {
+                        continue;
+                    }
                     $plugin->unenrol_user($instance, $userid);
                     echo "Succesfully unenroled user $userid\n";
                 }


### PR DESCRIPTION
Would you consider merging these changes?

New commands:

- course-assign-role
- course-disableenrolment
- course-enableguest
- course-reorder
- course-unassign-role

Changes:

- Add a couple of 'break' to course-enableselfenrol to stop after finding 1st matching enrolment instance.
- Add a --plugin option to course-unenrol to match enrolment plugin type.
- Add a --course-enrol-plugin option to course-enrol-plugin to match enrolment plugin type.
