### PR TITLE
fix 448 - corneltek/getoptionkit upgrade to commit aab2728d

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -228,7 +228,7 @@
   ],
   "require": {
     "mudrd8mz/moodle-tool_pluginskel":"dev-main",
-    "corneltek/getoptionkit": "dev-master#e815670d092e9b4993774c3e3ed608225dccf6a9",
+    "corneltek/getoptionkit": "dev-master#aab2728de80175217cab0d7a4d078c3eb907e2c0",
     "twig/twig": "1.44.7",
     "moodlehq/moodle-mod_newmodule": "dev-master#e1f112be8842291259ece87de3000cd5f0e18711",
     "danielneis/moodle-block_newblock": "dev-master#1fc89fb0845ad282426140feeb6bc3653efd1d7f",

--- a/composer.lock
+++ b/composer.lock
@@ -46,7 +46,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/GetOptionKit.git",
-                "reference": "e815670d092e9b4993774c3e3ed608225dccf6a9"
+                "reference": "aab2728de80175217cab0d7a4d078c3eb907e2c0"
             },
             "dist": {
                 "type": "zip",


### PR DESCRIPTION
Upgrade corneltek/getoptionkit to commit aab2728de80175217cab0d7a4d078c3eb907e2c0 to avoid several deprecation.

Seems that php 8.1 deprecations were resolved from this commit : https://github.com/c9s/GetOptionKit/commit/1121ee17f304cd7e2d8d2b818df86b6af5f07485