### PR TITLE
fix 482 - declare dynamic property filelist

### DIFF
--- a/Moosh/Command/Moodle39/Info/ChkDataDir.php
+++ b/Moosh/Command/Moodle39/Info/ChkDataDir.php
@@ -11,6 +11,8 @@ use Moosh\MooshCommand;
 
 class ChkDataDir extends MooshCommand
 {
+    var $filelist = '';
+    
     public function __construct() {
         parent::__construct('chkdatadir');
         $this->filelist = '';

--- a/Moosh/Command/Moodle39/Info/ChkDataDir.php
+++ b/Moosh/Command/Moodle39/Info/ChkDataDir.php
@@ -11,7 +11,7 @@ use Moosh\MooshCommand;
 
 class ChkDataDir extends MooshCommand
 {
-    var $filelist = '';
+    private $filelist;
     
     public function __construct() {
         parent::__construct('chkdatadir');


### PR DESCRIPTION
declare $filelist in class to avoid deprecated on dynamic property message

resolve issue https://github.com/tmuras/moosh/issues/482 (Creation of dynamic property in ChkDataDir.php)