### PR TITLE
MOOSH485 - Fix Dynamic Properties in CourseInfo.php

### DIFF
--- a/Moosh/Command/Moodle39/Course/CourseInfo.php
+++ b/Moosh/Command/Moodle39/Course/CourseInfo.php
@@ -51,6 +51,10 @@ class CourseInfo extends MooshCommand
     private $filesnumber;
     private $filesize;
 
+    private $enrolledtotal;
+    private $logsnumber;
+    private $data;
+
     public function __construct()
     {
         global $DB;


### PR DESCRIPTION
This fixes #485.

The properties $enrolledtotal, $logsnumber, and $data were not declared. This fix declares them as private class properties, removing the warning.