### PR TITLE
MOOSH485 - Fix Dynamic Properties - CourseInfo.php

### DIFF
--- a/Moosh/Command/Moodle39/Course/CourseInfo.php
+++ b/Moosh/Command/Moodle39/Course/CourseInfo.php
@@ -51,6 +51,10 @@ class CourseInfo extends MooshCommand
     private $filesnumber;
     private $filesize;
 
+    private $enrolledtotal;
+    private $logsnumber;
+    private $data;
+
     public function __construct()
     {
         global $DB;


### PR DESCRIPTION
Fixes #485.

Three properties weren't declared:

- $enrolledtotal
- $logsnumber
- $data

So I declared them as private properties to remove the deprecated messages.