### PR TITLE
New commands proposal

### DIFF
--- a/Moosh/Command/Generic/Plugin/PluginHideShow.php
+++ b/Moosh/Command/Generic/Plugin/PluginHideShow.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @auhtor  2021 Céline Pervès <cperves@unistra.fr>
+ * @copyright Université de Strasbourg unistra.fr
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Generic\Plugin;
+use Moosh\MooshCommand;
+
+class PluginHideShow extends MooshCommand
+{
+
+    public function __construct()
+    {
+        parent::__construct('hideshow', 'plugin');
+        $this->addArgument('plugintype');
+        $this->addArgument('pluginname');
+        $this->addArgument('show');
+    }
+
+    public function execute()
+    {
+        global $CFG,$DB;
+
+        if(!is_numeric($this->arguments[2])){
+            echo "hideshow must be an integer\n";
+            die;
+        }
+        $show=(int)$this->arguments[2];
+        $plugintype = $this->arguments[0];
+        $pluginname = $this->arguments[1];
+        switch($plugintype){
+            case 'block':
+                self::hideshow_values_check($pluginname,array(0,1));
+                if (!$block = $DB->get_record('block', array('name'=>$pluginname))) {
+                    echo "$plugintype $pluginname not exists";
+                    break;
+                }
+                $DB->set_field('block', 'visible', $show, array('id'=>$block->id));
+                add_to_config_log('block_visibility', $block->visible, ''.$show, $block->name);
+                \core_plugin_manager::reset_caches();
+                break;
+            case 'mod':
+                self::hideshow_values_check($show,array(0,1));
+                if (!$module = $DB->get_record("modules", array("name"=>$pluginname))) {
+                    echo "$plugintype $pluginname not exists";
+                    break;
+                }
+                $DB->set_field("modules", "visible", $show, array("id"=>$module->id)); // Hide main module
+                if($show==0){
+                    // Remember the visibility status in visibleold.
+                    // And hide...
+                    $sql = "UPDATE {course_modules}
+                                  SET visibleold=visible, visible=0
+                                WHERE module=?";
+                    $DB->execute($sql, array($module->id));
+                    // Increment course.cacherev for courses where we just made something invisible.
+                    // This will force cache rebuilding on the next request.
+                    increment_revision_number('course', 'cacherev',
+                        "id IN (SELECT DISTINCT course
+                                               FROM {course_modules}
+                                              WHERE visibleold=1 AND module=?)",
+                        array($module->id));
+                    \core_plugin_manager::reset_caches();
+                }else{
+                    $DB->set_field('course_modules', 'visible', '1', array('visibleold'=>1, 'module'=>$module->id)); // Get the previous saved visible state for the course module.
+                    // Increment course.cacherev for courses where we just made something visible.
+                    // This will force cache rebuilding on the next request.
+                    increment_revision_number('course', 'cacherev',
+                        "id IN (SELECT DISTINCT course
+                                               FROM {course_modules}
+                                              WHERE visible=1 AND module=?)",
+                        array($module->id));
+                    \core_plugin_manager::reset_caches();
+                }
+                break;
+            case 'assignfeedback':
+            case 'assignsubmission':
+                self::hideshow_values_check($show,array(0,1));
+                //check pluginname
+                if(count((array)get_config($plugintype.'_'.$pluginname))==0){
+                    cli_error(get_string('hideshow_plugin_cli_pluginnotexists','tool_cmdlinetools',array('name'=>$pluginname, 'type'=> $plugintype)));
+                }
+                set_config('disabled', $show==0?1:0, $plugintype . '_' . $pluginname);
+                break;
+            case 'qtype':
+                require_once($CFG->dirroot.'/question/engine/bank.php');
+                self::hideshow_values_check($show,array(0,1));
+                //check qtype
+                if(!array_key_exists ($pluginname, \question_bank::get_all_qtypes())){
+                    echo "qtype $pluginname does not exist";
+                }
+                if($show==0){
+                    set_config($pluginname . '_disabled',1, 'question');
+                }else{
+                    $qtype = \question_bank::get_qtype($pluginname,true);
+                    if (!$qtype->menu_name()) {
+                        echo "cannot enable qtype $pluginname";
+                        break;
+                    }
+                    unset_config($pluginname . '_disabled', 'question');
+                }
+                break;
+            case 'qbehaviour':
+                self::hideshow_values_check($show,array(0,1));
+                require_once($CFG->dirroot.'/question/engine/lib.php');
+                //check qbehaviour
+                if(!array_key_exists ($pluginname, core_component::get_plugin_list('qbehaviour'))){
+                    echo "qbehaviour $pluginname does not exist";
+                    break;
+                }
+                if(!question_engine::is_behaviour_archetypal($pluginname)){
+                    echo "can't enable/disable qbehaviour $pluginname";
+                    break;
+                }
+                $config = get_config('question');
+                if (!empty($config->disabledbehaviours)) {
+                    $disabledbehaviours = explode(',', $config->disabledbehaviours);
+                } else {
+                    $disabledbehaviours = array();
+                }
+                $disabledbehaviours_index = array_search($pluginname,$disabledbehaviours);
+                if($disabledbehaviours_index!==false && $show==1){
+                    unset($disabledbehaviours[$disabledbehaviours_index]);
+                    set_config('disabledbehaviours', implode(',', $disabledbehaviours), 'question');
+                }else if ($disabledbehaviours_index === false && $show ==0){
+                    $disabledbehaviours[] = $pluginname;
+                    set_config('disabledbehaviours', implode(',', $disabledbehaviours), 'question');
+                }
+                \core_plugin_manager::reset_caches();
+                break;
+            case 'enrol':
+                self::hideshow_values_check($show,array(0,1));
+                $syscontext = \context_system::instance();
+                $enabled = enrol_get_plugins(true);
+                $all     = enrol_get_plugins(false);
+                if(!array_key_exists($pluginname,$all)){
+                    echo "enrol method $pluginname not exists";
+                    break;
+                }
+                if($show==0 && array_key_exists($pluginname,$enabled)){
+                    unset($enabled[$pluginname]);
+                    set_config('enrol_plugins_enabled', implode(',', array_keys($enabled)));
+                    \core_plugin_manager::reset_caches();
+                    $syscontext->mark_dirty(); // resets all enrol caches
+                }else if($show == 1  && !array_key_exists($pluginname, $enabled)){
+                    $enabled = array_keys($enabled);
+                    $enabled[] = $pluginname;
+                    set_config('enrol_plugins_enabled', implode(',', $enabled));
+                    \core_plugin_manager::reset_caches();
+                    $syscontext->mark_dirty(); // resets all enrol caches
+                }
+                break;
+            case 'filter':
+                require_once($CFG->libdir.'/filterlib.php');
+                self::hideshow_values_check($show,array(1,-1,-9999));
+                //check if filter exists
+                if(!array_key_exists($pluginname,filter_get_all_installed())){
+                    echo "filter $pluginname does not exist";
+                    break;
+                }
+                filter_set_global_state('filter/'.$pluginname, $show);
+                if ($show == TEXTFILTER_DISABLED) {
+                    filter_set_applies_to_strings('filter/'.$pluginname, false);
+                }
+                reset_text_filters_cache();
+                break;
+            case 'editor':
+                self::hideshow_values_check($show,array(0,1));
+                $editors=editors_get_available();
+                if(!array_key_exists($pluginname,$editors)){
+                    echo "editor $pluginname doesn't exists";
+                    break;
+                }
+                $active_editors = explode(',', $CFG->texteditors);
+                $active_editors_index = array_search($pluginname,$active_editors);
+                if($show==0 && $active_editors_index !== false){
+                    unset($active_editors[$active_editors_index]);
+                    set_config('texteditors', implode(',', $active_editors));
+
+                }else if($show == 1  && $active_editors_index === false){
+                    $active_editors[]=$pluginname;
+                    set_config('texteditors', implode(',', $active_editors));
+                }
+                break;
+            case 'auth':
+                self::hideshow_values_check($show, array(0,1));
+                if(!exists_auth_plugin($pluginname)){
+                    echo "auth plugin $pluginname doesn't exists";
+                    break;
+                }
+                get_enabled_auth_plugins(true); // fix the list of enabled auths
+                if (empty($CFG->auth)) {
+                    $authsenabled = array();
+                } else {
+                    $authsenabled = explode(',', $CFG->auth);
+                }
+                if($show==1){
+                    if (!in_array($pluginname, $authsenabled)) {
+                        $authsenabled[] = $pluginname;
+                        $authsenabled = array_unique($authsenabled);
+                        set_config('auth', implode(',', $authsenabled));
+                    }
+                    \core\session\manager::gc(); // Remove stale sessions.
+                    \core_plugin_manager::reset_caches();
+                }else{
+                    $key = array_search($pluginname, $authsenabled);
+                    if ($key !== false) {
+                        unset($authsenabled[$key]);
+                        set_config('auth', implode(',', $authsenabled));
+                    }
+
+                    if ($pluginname == $CFG->registerauth) {
+                        set_config('registerauth', '');
+                    }
+                    \core\session\manager::gc(); // Remove stale sessions.
+                    \core_plugin_manager::reset_caches();
+                }
+                break;
+            case 'license':
+                self::hideshow_values_check($show, array(0,1));
+                require_once($CFG->libdir.'/licenselib.php');
+                if(license_manager::get_license_by_shortname($pluginname)==null){
+                    echo "license plugin $pluginname doesn't exists";
+                    break;
+                }
+                if($pluginname == $CFG->sitedefaultlicense){
+                    echo "can\'t enable/disable license $pluginname";
+                    break;
+                }
+                if($show==1){
+                    license_manager::enable($pluginname);
+                }else{
+                    license_manager::disable($pluginname);
+                }
+                break;
+            case 'repository':
+                echo 'not implemented because require repository setting form';
+                break;
+            case 'courseformat':
+                self::hideshow_values_check($show, array(0,1));
+                require_once($CFG->libdir.'/classes/plugin_manager.php');
+                $formatplugins = \core_plugin_manager::instance()->get_plugins_of_type('format');
+                if (!isset($formatplugins[$pluginname])) {
+                    echo "cours eformat $pluginname doesn't exits";
+                    break;
+                }
+                if (get_config('moodlecourse', 'format') === $pluginname){
+                    echo "course foramt $pluginname can't be enabled/disabled";
+                    break;
+                }
+                if($show == 0){
+                    set_config('disabled', 1, 'format_'. $pluginname);
+                    \core_plugin_manager::reset_caches();
+                }else{
+                    unset_config('disabled', 'format_'. $pluginname);
+                    \core_plugin_manager::reset_caches();
+                }
+                break;
+            case 'availability':
+                if($show==0){
+                    set_config('disabled', 1, 'availability_' . $pluginname);
+                }else{
+                    unset_config('disabled', 'availability_' . $pluginname);
+                }
+                \core_plugin_manager::reset_caches();
+                break;
+            default:
+                echo "bad plugin type $plugintype or not taken in charge";
+                break;
+        }
+    }
+    private static function hideshow_values_check($hideshow,$possiblevalues){
+        if(!in_array($hideshow, $possiblevalues)){
+            cli_error(get_string('hideshow_plugin_cli_parametervalues','tool_cmdlinetools',implode(',', $possiblevalues)));
+        }
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "This command enable to hide show a plugin";
+        $help .= "\n\nplugintype can be block, mod, assignfeedback, assignsubmission, qtype, qbehaviour, enrol, filter, editor, auth, license, repository, courseformat or avaibility";
+        return $help;
+    }
+}

--- a/Moosh/Command/Generic/Request/RequestSelect.php
+++ b/Moosh/Command/Generic/Request/RequestSelect.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @auhtor  2021 Céline Pervès <cperves@unistra.fr>
+ * @copyright Université de Strasbourg unistra.fr
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Generic\Request;
+
+use Moosh\MooshCommand;
+
+class RequestSelect extends MooshCommand {
+    public function __construct() {
+        parent::__construct('select', 'request');
+        $this->addArgument('select_query');
+        $this->minArguments = 1;
+        $this->maxArguments = 1;
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "This command enable to make a select query and return resultset into a csv format";
+        return $help;
+    }
+
+
+    public function execute() {
+        global $CFG, $DB;
+        $selectquery = trim($this->arguments[0]);
+        cli_writeln("$selectquery");
+        $results = $DB->get_records_sql($selectquery);
+        $output = '';
+        foreach($results as $index=>$result) {
+            $output.=implode(';',(array) $result)."\n";
+        }
+        echo $output;
+    }
+}
+
+

--- a/Moosh/Command/Moodle39/Cache/CacheSet.php
+++ b/Moosh/Command/Moodle39/Cache/CacheSet.php
@@ -57,7 +57,7 @@ class CacheSet extends MooshCommand
     protected function getArgumentsHelp() {
         $help = parent::getArgumentsHelp();
         $help .= "\n\n";
-        $help .= "This command enable to attribute cache to specific cache store";
+        $help .= "This command enable to attribute cache to specific cache definition";
         $help .= "\ne.g moosh -n cache-set core/calendar_subscriptions redisstore";
         return $help;
     }

--- a/Moosh/Command/Moodle39/Cache/CacheSet.php
+++ b/Moosh/Command/Moodle39/Cache/CacheSet.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Cache;
+use Moosh\MooshCommand;
+
+class CacheSet extends MooshCommand
+{
+    public function __construct() {
+        parent::__construct('set', 'cache');
+        $this->addArgument('definition');
+        $this->addArgument('mapping');
+    }
+
+    public function execute()
+    {
+        global $CFG;
+        require_once($CFG->dirroot.'/cache/locallib.php');
+        $var_definition=$this->arguments[0];
+        $var_mappings=$this->arguments[1];
+        if(!isset($var_definition) || !isset($var_mappings) ){
+            cli_error('Defintion and mampings are required');
+        }
+        $factory = \cache_factory::instance();
+        list($component, $area) = explode('/', $var_definition, 2);
+        $config = \cache_config::instance();
+        $writer = \cache_config_writer::instance();
+        $writer->update_definitions();
+        $definition_check = $writer->get_definition_by_id($var_definition);
+        if (!$definition_check) {
+            cli_error("$var_definition cache definition not exists");
+        }
+        $definition = $factory->create_definition($component, $area);
+        $possiblestores = $config->get_stores($definition->get_mode(), $definition->get_requirements_bin());
+
+        $var_mappings = explode(',',$var_mappings);
+        $mappings = array();
+        foreach ($var_mappings as $index => $var_mapping){
+            // Check mapping is available.
+            if (array_key_exists($var_mapping, $possiblestores)){
+                $mappings[$index]= $var_mapping;
+            }else if(!empty($var_mapping)){
+                cli_error("Bad store instance name mapping $var_mapping : does not exists or not usable for this cache mode");
+            }
+        }
+        $writer->set_definition_mappings($var_definition, $mappings);
+        return true;
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "This command enable to attribute cache to specific cache store";
+        $help .= "\ne.g moosh -n cache-set core/calendar_subscriptions redisstore";
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle39/Category/CategoryMoveCoursesFromCategoryToAnother.php
+++ b/Moosh/Command/Moodle39/Category/CategoryMoveCoursesFromCategoryToAnother.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Category;
+use Moosh\MooshCommand;
+
+class CategoryMoveCoursesFromCategoryToAnother extends MooshCommand {
+
+    public function __construct() {
+        parent::__construct('move-courses-from-category-to-another', 'category');
+        $this->addArgument('sourcecategory');
+        $this->addArgument('destinationcategory');
+        $this->minArguments = 2;
+    }
+
+    public function execute()
+    {
+        global $DB, $CFG;
+        require_once($CFG->dirroot.'/course/classes/category.php');
+        require_once($CFG->dirroot.'/course/lib.php');
+        // Check that category ids exists.
+        try {
+            $sourcecategory = \core_course_category::get($this->arguments[0]);
+        } catch (moodle_exception $me){
+            cli_error('source category does not exists');
+        }
+        try {
+            $destinationcategory = \core_course_category::get($this->arguments[1]);
+        } catch(moodle_exception $me){
+            cli_error('destination category does not exists');
+        }
+        $courses = $DB->get_records('course', array('category'=> $sourcecategory->id));
+        if(count($courses)==0){
+            cli_writeln('no courses in source category');
+        }
+        foreach( $courses as $coursedata){
+            // change category
+            $coursedata->category = $destinationcategory->id;
+            $msgobject = new \stdClass();
+            $msgobject->courseid = $coursedata->id;
+            $msgobject->course = $coursedata->shortname;
+            $msgobject->sourcecategory = $sourcecategory->name;
+            $msgobject->sourcecategoryid = $sourcecategory->id;
+            $msgobject->destinationcategory = $destinationcategory->name;
+            $msgobject->destinationcategoryid = $destinationcategory->id;
+            update_course($coursedata);
+            cli_writeln("course $msgobject->course ($msgobject->courseid) moved from category $msgobject->sourcecategory (id=$msgobject->sourcecategoryid) to category $msgobject->destinationcategory (id=$msgobject->destinationcategoryid)");
+        }
+    }
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "This command enable to move all courses included into a source cateogry into a destination category";
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle39/Cohort/CohortDelete.php
+++ b/Moosh/Command/Moodle39/Cohort/CohortDelete.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Cohort;
+use Moosh\MooshCommand;
+use context_coursecat;
+
+class CohortDelete extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('delete', 'cohort');
+
+        $this->addArgument('ids');
+        $this->maxArguments = 255;
+    }
+
+    public function execute()
+    {
+        global $CFG, $DB;
+
+        require_once $CFG->dirroot . '/cohort/lib.php';
+
+        foreach ($this->arguments as $argument) {
+            $ids = explode(',', $argument);
+            foreach ($ids as $id) {
+                $cohort = $DB->get_record('cohort',array('id'=>$id));
+                if (!$cohort) {
+                    echo "Cohort $id does not exists\n";
+                    continue;
+                }
+                cohort_delete_cohort($cohort);
+                cli_writeln("cohort $id deleted");
+            }
+        }
+    }
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "Delete cohort";
+        $help .= "\n'cohort ids separated by , (max 255 characters)'";
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle39/Context/ContextFreeze.php
+++ b/Moosh/Command/Moodle39/Context/ContextFreeze.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Context;
+
+use Moosh\MooshCommand;
+use context_course;
+use course_enrolment_manager;
+
+class ContextFreeze extends MooshCommand {
+    public function __construct() {
+        parent::__construct('freeze', 'context');
+        $this->addArgument('instanceid');
+        $this->addArgument('contextlevel');
+        $this->addArgument('lock');
+    }
+    public function execute(){
+        global $CFG;
+        require_once("{$CFG->libdir}/accesslib.php");
+        require_once("{$CFG->libdir}/adminlib.php");
+        $instanceid = $this->arguments[0];
+        $contextlevel = $this->arguments[1];
+        $lock = $this->arguments[2];
+        $context = null;
+        switch($contextlevel){
+            case CONTEXT_SYSTEM :
+                $context = \context_system::instance();
+                break;
+            case CONTEXT_COURSE :
+                $context = \context_course::instance($instanceid);
+                break;
+            case CONTEXT_COURSECAT :
+                $context = \context_coursecat::instance($instanceid);
+                break;
+            case CONTEXT_MODULE :
+                $context = \context_module::instance($instanceid);
+                break;
+            case CONTEXT_BLOCK :
+                $context = \context_block::instance($instanceid);
+                break;
+            case CONTEXT_USER :
+                $context = \context_user::instance($instanceid);
+                break;
+            default:
+                cli_error("bad context level $contextlevel");
+        }
+        if($context){
+            $context->set_locked($lock);
+            if($lock){
+                cli_writeln("context locked");
+            } else {
+                cli_writeln("context unlocked");
+            }
+        } else {
+            cli_error("context not found");
+        }
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "Freeze a context";
+        $help .= "\ncontext are moodle context levels integer";
+        $help .= "\nlock is 1 or 0";
+
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle39/Course/CourseEnrolChangeStatus.php
+++ b/Moosh/Command/Moodle39/Course/CourseEnrolChangeStatus.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Course;
+use Moosh\MooshCommand;
+
+class CourseEnrolChangeStatus extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('enrol-change-status', 'course');
+
+        $this->addOption('i|instanceid:', 'enrolment instance id', 0);
+        $this->addOption('s|status', 'status to be applied 0 for disable, 1 for enable',0);
+        $this->addArgument('courseid');
+        $this->maxArguments = 255;
+    }
+
+    function choice_value_check_and_prompt($promptmsg, $values){
+        $var = trim(cli_input($promptmsg));
+        if (!is_numeric($var) && ( in_array($var, $values))) {
+            cli_writeln('Entered value must be an int in ('.implode(',', $values).')');
+            return self::choice_value_check_and_prompt();
+        }
+        return (int)$var;
+    }
+
+    public function execute()
+    {
+        global $CFG, $DB;
+
+        require_once $CFG->dirroot . '/course/lib.php';
+        $instanceid = $this->expandedOptions['instanceid'];
+        $status = $this->expandedOptions['status'];
+        $courseid = $this->arguments[0];
+        if($courseid == 0) {
+            cli_error('you must enter a valid courseid');
+        }
+        $course = $DB->get_record('course', array('id' => $courseid));
+        if (!$course) {
+            cli_error("course $courseid not found");
+        }
+        $instances = enrol_get_instances($course->id, false);
+        if( $instanceid == 0) {
+            // Enter in interactive mode
+            cli_writeln('Interactive mode');
+            $options = array();
+            foreach ($instances as $instance) {
+                $options[] = $instance->id;
+                cli_writeln("$instance->id : $instance->name - $instance->enrol - "
+                    .($instance->status == ENROL_INSTANCE_ENABLED ? "enabled" : "disabled"));
+            }
+            $instanceid = self::choice_value_check_and_prompt(
+                "please choose what enrol method you want to enable/disable by typeing is instance id",
+                $options
+            );
+            $status = self::choice_value_check_and_prompt(
+                "enable ".ENROL_INSTANCE_ENABLED." or disable ".ENROL_INSTANCE_DISABLED,
+                array(ENROL_INSTANCE_ENABLED,ENROL_INSTANCE_DISABLED));
+            //$progress = new \progress_trace_buffer(new \text_progress_trace(), false);
+            $plugin = enrol_get_plugin($instances[$instanceid]->enrol);
+            $plugin->update_status($instances[$instanceid],$status);
+            cli_writeln("instance $instanceid as be passed to ".($status == ENROL_INSTANCE_ENABLED? "enabled" : "disabled" ));
+        } else {
+            // non interactive mode change status by id
+            $plugin = enrol_get_plugin($instances[$instanceid]->enrol);
+            $plugin->update_status($instances[$instanceid],$status);
+            cli_writeln("instance $instanceid as be passed to ".($status == ENROL_INSTANCE_ENABLED? "enabled" : "disabled" ));
+        }
+    }
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "Change enrol status";
+
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle39/Dashboard/DashboardResetAll.php
+++ b/Moosh/Command/Moodle39/Dashboard/DashboardResetAll.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ *
+ * 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Dashboard;
+use Moosh\MooshCommand;
+
+class DashboardResetAll extends MooshCommand
+{
+    public function __construct() {
+        parent::__construct('reset-all', 'dashboard');
+    }
+    public function execute()
+    {
+        global $CFG;
+        require_once($CFG->dirroot.'/my/lib.php');
+        my_reset_page_for_all_users(MY_PAGE_PRIVATE, 'my-index');
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "Reset all dashboards";
+
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle39/Task/TaskSchedule.php
+++ b/Moosh/Command/Moodle39/Task/TaskSchedule.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author  2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Task;
+use Moosh\MooshCommand;
+
+class TaskSchedule extends MooshCommand
+{
+
+    public function __construct() {
+        parent::__construct('schedule', 'task');
+        $this->addOption('M|minute:', 'minute');
+        $this->addOption('H|hour:', 'hour');
+        $this->addOption('d|day:', 'day');
+        $this->addOption('m|month:', 'month');
+        $this->addOption('w|dayofweek:', 'Day of week');
+        $this->addOption('x|disabled:', 'Disbaled');
+        $this->addOption('r|resettodefaults:', 'Reset to defaults', 0);
+        $this->addArgument('taskname');
+        $this->minArguments = 0;
+        $this->maxArguments = 1;
+
+    }
+
+    public function execute()
+    {
+        if(count($this->arguments) == 0){
+            $tasks = \core\task\manager::get_all_scheduled_tasks();
+            $tasknames = array();
+            foreach($tasks as $currenttask){
+                $tasknames[] = get_class($currenttask);
+            }
+            cli_writeln('Available task names are :');
+            cli_writeln(implode(PHP_EOL, $tasknames));
+            die;
+        }
+        $taskname = $this->arguments[0];
+        $task = \core\task\manager::get_scheduled_task($taskname);
+        if (!$task) {
+            cli_error("task $taskname not exists");
+        }
+        if (!empty($this->expandedOptions['resettodefaults'])) {
+            $defaulttask = \core\task\manager::get_default_scheduled_task($taskname);
+            $task->set_minute($defaulttask->get_minute());
+            $task->set_hour($defaulttask->get_hour());
+            $task->set_month($defaulttask->get_month());
+            $task->set_day_of_week($defaulttask->get_day_of_week());
+            $task->set_day($defaulttask->get_day());
+            $task->set_disabled($defaulttask->get_disabled());
+            $task->set_customised(false);
+        } else {
+            if(!empty($this->expandedOptions['minute'])){
+                $task->set_minute($this->expandedOptions['minute']);
+            }
+            if(!empty($this->expandedOptions['hour'])) {
+                $task->set_hour($this->expandedOptions['hour']);
+            }
+            if(!empty($this->expandedOptions['month'])) {
+                $task->set_month($this->expandedOptions['month']);
+            }
+            if(!empty($this->expandedOptions['dayofweek'])) {
+                $task->set_day_of_week($this->expandedOptions['dayofweek']);
+            }
+            if(!empty($this->expandedOptions['day'])) {
+                $task->set_day($this->expandedOptions['day']);
+            }
+            if(!empty($this->expandedOptions['disabled'])) {
+                $task->set_disabled($this->expandedOptions['disabled']);
+            }
+            $task->set_customised(true);
+        }
+        try {
+            \core\task\manager::configure_scheduled_task($task);
+            cli_writeln("Task configured");
+        } catch (Exception $e) {
+            cli_writeln("error while configuring task $taskname");
+            cli_error($e->getMessage());
+        }
+    }
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "Schedule Moodle task";
+
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle39/Webservice/WebserviceInstall.php
+++ b/Moosh/Command/Moodle39/Webservice/WebserviceInstall.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Webservice;
+use Moosh\MooshCommand;
+
+class WebserviceInstall extends MooshCommand
+{
+    public function __construct() {
+        parent::__construct('install', 'webservice');
+        $this->addArgument('servicename');
+        $this->addArgument('capabilities');
+        $this->addOption('m|mail:', 'mail');
+        $this->addOption('u|username:', 'user name');
+        $this->addOption('r|rolename:', 'role name');
+        $this->addOption('i|iprestriction:',' ip restriction', '');
+        $this->addOption('v|validuntil:', 'valid until', 0);
+    }
+
+    public function execute()
+    {
+        global $DB, $CFG;
+        require_once($CFG->dirroot.'/user/lib.php');
+        require_once($CFG->dirroot.'/webservice/lib.php');
+        $servicename = $this->arguments[0];
+        $service = $DB->get_record('external_services', array('shortname' => $servicename));
+        if(!$service) {
+            echo "service $servicename does not exist".PHP_EOL;
+            return;
+        }
+        $capabilities = explode(',', $this->arguments[1]);
+        $rolename = $this->expandedOptions['rolename'] ? $this->expandedOptions['rolename'] : 'role_'.$servicename;
+        $username=  $this->expandedOptions['username'] ? $this->expandedOptions['username'] : 'user_'.$servicename;
+        $iprestriction = $this->expandedOptions['iprestriction'];
+        $validuntil = $this->expandedOptions['validuntil'];
+        // Create user.
+        $email = null;
+        if ($this->expandedOptions['mail']) {
+            $email = $this->expandedOptions['mail'];
+        } else {
+            $noreplyuser = \core_user::get_noreply_user();
+            $email= $servicename.'_'.$noreplyuser->email;
+        }
+        // Check if user exits.
+        $wsuserid = 0;
+        $userobject = $DB->get_record('user', array('username' => $username));
+        if($userobject) {
+            $wsuserid = $userobject->id;
+            echo "user $username already exists so will use it".PHP_EOL;
+        } else {
+            $user = new \stdClass();
+            $user->username = $username;
+            $user->firstname = $username;
+            $user->lastname = $username;
+            $user->email = $email;
+            $user->confirmed=1;
+            $user->policyagreed=1;
+            $user->mnethostid = $CFG->mnet_localhost_id;
+            $wsuserid = user_create_user($user);
+        }
+        // Create Role
+        $systemcontext = \context_system::instance();
+        $rolerecord = $DB->get_record('role', array('shortname' => $rolename));
+        $wsroleid = 0;
+        if ($rolerecord) {
+            $wsroleid = $rolerecord->id;
+            echo "role $rolename already exists, we'll use it".PHP_EOL;
+        } else {
+            $wsroleid = create_role(
+                $rolename,
+                $rolename,
+                $rolename
+            );
+        }
+        // Assign necessary capabilities
+        foreach($capabilities as $capability){
+            $capability = trim($capability);
+            $capaobject = $DB->get_record('capabilities', array('name' => $capability));
+            if(!$capability){
+                echo "capability $capability not exists".PHP_EOL;
+                continue;
+            }
+            assign_capability($capability, CAP_ALLOW,
+                $wsroleid, $systemcontext->id, true);
+        }
+        // Allow role assignment on system.
+        set_role_contextlevels($wsroleid, array(10 => 10));
+        // Assign role to user.
+        role_assign($wsroleid, $wsuserid, $systemcontext->id);
+        // Assign user to webservice.
+        $webservicemanager = new \webservice();
+        $serviceuser = new \stdClass();
+        $serviceuser->externalserviceid = $service->id;
+        $serviceuser->userid = $wsuserid;
+        $serviceuser->iprestriction = $iprestriction;
+
+        $webservicemanager->add_ws_authorised_user($serviceuser);
+        // Trigger events.
+        $params = array(
+            'objectid' => $serviceuser->externalserviceid,
+            'relateduserid' => $serviceuser->userid
+        );
+        $event = \core\event\webservice_service_user_added::create($params);
+        $event->trigger();
+        // Take admin role
+        // Generate Token.
+        $token = external_generate_token(EXTERNAL_TOKEN_PERMANENT, $service->id, $wsuserid, $systemcontext->id, $validuntil, $iprestriction);
+        echo "Webservice $servicename installed : user $username and role $rolename".PHP_EOL;
+        echo "Token generated $token";
+    }
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "Install a webservice ";
+        $help .= "\ncapabilities are seperated by a commas.\n\n";
+        $help .= "\nif user is not defined, user_servicename will be created";
+        $help .= "\nif role is not defined, role_servicename will be created";
+
+        return $help;
+    }
+}

--- a/Moosh/Command/Moodle41/Cache/CacheStoreClear.php
+++ b/Moosh/Command/Moodle41/Cache/CacheStoreClear.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * moosh - Moodle Shell
+ *
+ * @copyright 2021 unistra {@link http://unistra.fr}
+ * @author 2021 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle41\Cache;
+use Moosh\MooshCommand;
+
+class CacheStoreClear extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('store-clear', 'cache');
+        $this->addOption('d|definition:', 'cache definition, command will only purge this cache definition');
+        $this->addArgument('storename');
+        $this->minArguments = 1;
+    }
+
+    public function execute()
+    {
+        global $CFG;
+        require_once($CFG->dirroot.'/cache/classes/factory.php');
+        require_once($CFG->dirroot.'/cache/classes/helper.php');
+        $instance = \cache_config::instance();
+        $factory = \cache_factory::instance();
+        $config = $factory->create_config_instance();
+        $stores = $instance->get_all_stores();
+        $this->expandOptionsManually($this->arguments);
+        $options = $this->expandedOptions;
+        $storename = $this->arguments[0];
+        if (!array_key_exists($storename, $stores)) {
+            cli_error("Store with name $storename does not exists.");
+        }
+        $storedetails= $stores[$storename];
+        $class = $storedetails['class'];
+        $storeinstance = new $class($storedetails['name'], $storedetails['configuration']);
+        if (!$storeinstance->are_requirements_met()){
+            cli_error("Store $storename does not meet requirements.");
+        }
+        if(!$storeinstance->is_ready()) {
+            cli_error("Store $storename si not ready.");
+        }
+        $definitionid = $options['definition'];
+        if (!empty($options['definition'])) {
+            $definitions = $config->get_definitions();
+            if (!array_key_exists($definitionid, $definitions)) {
+                cli_error("Cache definition $definitionid not found in the $storename cache store.");
+            }
+            $definition = $definitions[$definitionid];
+            $definition = \cache_definition::load($definitionid, $definition);
+            $definitioninstance = clone($storeinstance);
+            $definitioninstance->initialise($definition);
+            if (!$definitioninstance->purge()) {
+                cli_error("For $storename cache store , Cache definition $definitionid purge return false.");
+            } else {
+                cli_writeln("Cache definition $definitionid in $storename cache store sucessfully purged.");
+            }
+            unset($definitioninstance);
+        } else {
+            // Purge all cache definitions.
+            if (\cache_helper::purge_store($storename,$config)) {
+                cli_writeln("Store $storename purged.");
+            } else {
+                cli_error("Store $storename purge returned false.");
+            }
+        }
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "Clear a specific cache";
+        $help .= "\nIt is possible to only clean a cache definition";
+
+        return $help;
+    }
+}


### PR DESCRIPTION
Hello,
First of all, thanks a lot for this very usefull Moosh tool.
It help us in our everyday work.
Would you be interested in adding this few commands I made for my University?

- plugin-hideshow -> hide or show a plugin
- request-select -> A select command with a csv output
- cache-set -> This command enable to attribute cache to specific cache definition
- category-move-courses-from-category-to-another -> Move all courses of a category into an other one
- cohort-delete -> Delete a cohort
- context-freeze -> Freeze a context
- course-enrol-change-status -> Change enrol status in a course
- dashboard-reset-all -> Reset all deashboards
- task-schedule -> Schedule Moodle task
- webservice-install -> Install a webservice
- cache-store-clear -> Clear a specific cache

Regards
Céline - Université de Strasbourg
