### PR TITLE
MSH-492 Fix cohort-enrol course cohort sync

### DIFF
--- a/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
+++ b/Moosh/Command/Moodle39/Cohort/CohortEnrol.php
@@ -84,8 +84,9 @@ class CohortEnrol extends MooshCommand
 
                 foreach($cohorts as $cohort) {
 
-                    // Check if cohort enrolment already exists
-                    if ($cohortenrolment = $DB->get_record('enrol',array('customint1'=>$cohort->id,'courseid'=>$options['courseid'],'roleid'=>$role->id))) {
+                    // Check if cohort enrolment already exists.
+                    if ($cohortenrolment = $DB->get_record('enrol', ['enrol' => 'cohort', 'customint1' => $cohort->id,
+                        'courseid' => $options['courseid'], 'roleid' => $role->id])) {
                         echo " Notice: Cohort already enrolled into course\n";
                     } else {
 


### PR DESCRIPTION
If a cohort-enrol -c XX "cohortname" is run and the id for "cohortname" matches another `customint1` in the `mdl_enrol` table for that course, it will state that the cohort is already enrolled when it's not. This verifies that the `customint1` is for the `cohort` enrol type.

The fix was just to add `'enrol' => 'cohort'` to make sure that we're only looking at enrollment plugins where `customint1` matches AND it's a cohort sync enrollment.

Edit to add: This closes #492 