### PR TITLE
MSH494 - Replace deprecated random_bytes_emulate()

### DIFF
--- a/Moosh/Command/Moodle39/Dev/GenerateFiles.php
+++ b/Moosh/Command/Moodle39/Dev/GenerateFiles.php
@@ -163,7 +163,7 @@ class GenerateFiles extends MooshCommand
 
             // Generate random binary data (different for each file so it
             // doesn't compress unrealistically).
-            $data = random_bytes_emulate($this->filesize);
+            $data = random_bytes($this->filesize);
 
             $fs->create_file_from_string($filerecord, $data);
             $this->dot($i, $count);


### PR DESCRIPTION
Fixes #494 - use the `random_bytes()` present in currently supported PHP version instead.