### PR TITLE
new course-change-format command to change course format enabling upd…

### DIFF
--- a/Moosh/Command/Moodle41/Course/ChangeFormat.php
+++ b/Moosh/Command/Moodle41/Course/ChangeFormat.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Course Change format moosh
+ * moosh - Moodle Shell
+ * @copyright 2025 unistra {@link http://unistra.fr}
+ * @author 2025 Céline Perves <cperves@unistra.fr>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle41\Course;
+use Moosh\MooshCommand;
+
+class ChangeFormat extends MooshCommand {
+    public function __construct() {
+        parent::__construct("change-format", "course");
+        $this->addArgument('courseid');
+        $this->addArgument('format');
+    }
+    public function execute(){
+        global $DB, $CFG;
+        require_once($CFG->dirroot.'/course/lib.php');
+        require_once($CFG->libdir.'/classes/plugininfo/format.php');
+
+        $courseid = trim($this->arguments[0]);
+        $format = trim($this->arguments[1]);
+        // Check that course format exists
+        $formatplugins = \core\plugininfo\format::get_enabled_plugins();
+        if (!isset($formatplugins[$format])) {
+            cli_error("Format $format not found");
+        }
+        $oldcourse = $DB->get_record('course', array( 'id' => $courseid));
+        if (!$oldcourse) {
+            cli_error("course $courseid not found");
+        }
+        $course = $oldcourse;
+        $course->format = $format;
+        update_course($course); // editoroptions can be set to null since no summary editor options were changed
+        cli_writeln("course format for $courseid sucessfully changed to $format");
+    }
+
+    protected function getArgumentsHelp() {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "This command enable to change a course format";
+        return $help;
+    }
+}

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -784,6 +784,15 @@ Example 3: Backup course id=3 without any user data (excludes users, logs, grade
     moosh course-backup --template 3
 
 
+cours-change-format
+-------------------
+
+This command will change the format of a course to another one, triggering all the necessary changes to course such like image transfert.
+
+Example : For a course of id 3 that is in grid format, it will pass to tiles, migrating image for the new course format
+
+    moosh course-change-format 3 tiles
+
 course-cleanup
 --------------
 


### PR DESCRIPTION
Hello,
In this pull request you'll find a a new moosh command enabling to change course format for a given course, launching  update_course_format_options through update_course which is essential for course format changes for example for transfering images from grid format to tiles ones.

Hope it will be useful for community.
Regards
Céline