### PR TITLE
Enhance Course Enrolment Commands with Extra Options and a Listing Command

### DIFF
--- a/Moosh/Command/Moodle39/Course/CourseEnableselfenrol.php
+++ b/Moosh/Command/Moodle39/Course/CourseEnableselfenrol.php
@@ -17,6 +17,22 @@ class CourseEnableselfenrol extends MooshCommand
 
         $this->addOption('k|key:', 'enrolment key - defaults to none');
 
+        $this->addOption('r|roleid:', 'numerical id of the role to assign to users');
+
+        $this->addOption('n|name:', 'custom name for the self enrolment instance');
+
+        $this->addOption(
+            's|sendmessage:',
+            'send welcome message to new users - accepts integer values:
+             0 - Do not send the welcome email.
+             1 - Send welcome email from course contact.
+             2 - Send welcome email from course key holder.
+             3 - Send welcome email from no reply.',
+            '__NOT_SET__'
+        );
+
+        $this->addOption('m|message:', 'welcome message to new users');
+
         $this->addArgument('id');
 
         $this->maxArguments = 255;
@@ -27,23 +43,50 @@ class CourseEnableselfenrol extends MooshCommand
         global $CFG, $DB;
 
         require_once $CFG->dirroot . '/course/lib.php';
-        
+
         foreach ($this->arguments as $argument) {
             $this->expandOptionsManually(array($argument));
             $options = $this->expandedOptions;
-            
+
+            // retrieve and validate the role id if provided
+            $roleid = null;
+            if ($options['roleid']) {
+                $roleidInput = trim($options['roleid']);
+                if (!ctype_digit($roleidInput)) {
+                    throw new \Exception('The --roleid option must be an integer.');
+                }
+                $roleid = intval($roleidInput);
+                if (!$DB->record_exists('role', array('id' => $roleid))) {
+                    throw new \Exception('Invalid role id provided.');
+                }
+            }
+
+            // retrieve and validate the send message option if provided
+            if ($options['sendmessage'] !== '__NOT_SET__') {
+                $sendMessageInput = trim($options['sendmessage']);
+                if (!ctype_digit($sendMessageInput)) {
+                    throw new \Exception('The --sendmessage option must be an integer between 0 and 3.');
+                }
+                $sendMessage = intval($sendMessageInput);
+                if (!in_array($sendMessage, [0, 1, 2, 3], true)) {
+                    throw new \Exception('Invalid value for --sendmessage. Allowed values are 0, 1, 2, or 3.');
+                }
+            } else {
+                $sendMessage = null;
+            }
+
             // get the details for the course
             $course = $DB->get_record('course', array('id'=>$argument), '*', MUST_EXIST);
-            
+
             // get the details of the self enrolment plugin
             $plugin = enrol_get_plugin('self');
             if(!$plugin){
                 throw new \Exception('could not find self enrolment plugin');
             }
-            
+
             // get the enrolment plugin instances for the course
             $instances = enrol_get_instances($course->id, false);
-        
+
             // loop through the instances to find the instance ID for the self-enrolment plugin
             $selfEnrolInstance = 0;
             foreach($instances as $instance){
@@ -52,13 +95,13 @@ class CourseEnableselfenrol extends MooshCommand
                     break;
                 }
             }
-            
+
             // if we didn't find an instance for the self enrolment plugin then we need to add
             // one to the course
             if(!$selfEnrolInstance){
                 // first try add an instance
                 $plugin->add_default_instance($course);
-                
+
                 // then try retreive it
                 $instances = enrol_get_instances($course->id, false);
                 $selfEnrolInstance = 0;
@@ -68,21 +111,42 @@ class CourseEnableselfenrol extends MooshCommand
                         break;
                     }
                 }
-                
+
                 // if we still didn't get an instance - give up
                 if(!$selfEnrolInstance){
                     throw new \Exception('failed to create instance of self enrolment plugin');
                 }
             }
-            
+
             // activate self enrolment
             if ($selfEnrolInstance->status != ENROL_INSTANCE_ENABLED) {
                 $plugin->update_status($selfEnrolInstance, ENROL_INSTANCE_ENABLED);
             }
-            
+
             // set the enrolment key (always do this so running without the -k option will blank a pre-existing key)
             $instance_fromDB = $DB->get_record('enrol', array('courseid'=>$course->id, 'enrol'=>'self', 'id'=>$selfEnrolInstance->id), '*', MUST_EXIST);
             $instance_fromDB->password = $options['key'];
+
+            // set the role if provided
+            if ($roleid) {
+                $instance_fromDB->roleid = $roleid;
+            }
+
+            // set the custom name if provided
+            if ($options['name']) {
+                $instance_fromDB->name = $options['name'];
+            }
+
+            // set the send message option if provided
+            if ($sendMessage !== null) {
+                $instance_fromDB->customint4 = $sendMessage;
+            }
+
+            // set the welcome message if provided
+            if ($options['message']) {
+                $instance_fromDB->customtext1 = $options['message'];
+            }
+
             $DB->update_record('enrol', $instance_fromDB);
         }
     }

--- a/Moosh/Command/Moodle39/Course/CourseEnrolList.php
+++ b/Moosh/Command/Moodle39/Course/CourseEnrolList.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * moosh - Moodle Shell
+ *
+ * List all enrolment instances for a given course.
+ *
+ * @copyright  2025 University of Siegen
+ * @author     2025 Timo Hardebusch
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Course;
+
+use Moosh\MooshCommand;
+
+class CourseEnrolList extends MooshCommand
+{
+    public function __construct()
+    {
+        parent::__construct('enrol-list', 'course');
+
+        $this->addArgument('courseid');
+
+        $this->maxArguments = 255;
+    }
+
+    public function execute()
+    {
+        global $CFG, $DB;
+
+        require_once $CFG->dirroot . '/course/lib.php';
+
+        foreach ($this->arguments as $courseid) {
+            if ($courseid == 0) {
+                cli_error('You must enter a valid courseid.');
+            }
+
+            // Get the course record.
+            $course = $DB->get_record('course', ['id' => $courseid]);
+            if (!$course) {
+                cli_error("Course $courseid not found.");
+            }
+
+            cli_writeln("Enrolment methods for course id {$courseid}:");
+
+            // Retrieve enrolment instances for the course.
+            $instances = enrol_get_instances($course->id, false);
+
+            // If no enrolment methods are found, print a message.
+            if (empty($instances)) {
+                cli_writeln("  No enrolment methods found.");
+                continue;
+            }
+
+            // Loop through each enrolment instance and display its details.
+            foreach ($instances as $instance) {
+                $statusText = ($instance->status == ENROL_INSTANCE_ENABLED) ? "enabled" : "disabled";
+                cli_writeln("  $instance->id : $instance->name - $instance->enrol - $statusText");
+            }
+        }
+    }
+
+    protected function getArgumentsHelp()
+    {
+        $help = parent::getArgumentsHelp();
+        $help .= "\n\n";
+        $help .= "List enrolment methods for a given course.\n";
+        $help .= "Each enrolment method is displayed with its instance id, name, type and status (enabled/disabled).";
+        return $help;
+    }
+}

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -894,10 +894,46 @@ Example1 : change course enrolment instance status to disable for instance 42
 
     moosh course-enrol-change-status -i=42 -s=1 2
 
+course-enrol-list
+----------------------
+
+List all enrolment instances for one or more courses given a list of course IDs.
+
+Example 1: List all enrolment instances for course 42
+
+    moosh course-enrol-list 42
+
 course-enableselfenrol
 ----------------------
 
-Enable self enrolment on one or more courses given a list of course IDs. By default self enrolment is enabled without an enrolment key, but one can be passed as an option.
+Enable self enrolment on one or more courses given a list of course IDs. By default self enrolment is enabled without an enrolment key, but one can be passed as an option. In addition, you can customize the self-enrolment instance by specifying a role, a custom instance name, welcome message settings, and a custom welcome message.
+
+Options
+
+* --key, -k &lt;enrolmentkey&gt;
+  Set an enrolment key. If omitted, any pre-existing key will be blanked.
+
+* --roleid, -r &lt;roleid&gt;
+  Specify the numerical ID of the role to assign to newly enrolled users.
+
+* --name, -n &lt;custom name&gt;
+  Provide a custom name for the self-enrolment instance.
+
+* --sendmessage, -s &lt;integer&gt;
+  Control the welcome email for new users. Accepts integer values:
+  - `0` - Do not send the welcome email.
+  - `1` - Send welcome email from course contact.
+  - `2` - Send welcome email from course key holder.
+  - `3` - Send welcome email from no reply.
+  If not provided, the welcome message setting is left unchanged.
+
+* --message, -m &lt;text&gt;
+  Specify the welcome message text to send to new users.
+
+Arguments
+
+- id
+  One or more course IDs for which self enrolment should be enabled.
 
 Example 1: Enable self enrolment on a course without an enrolment key
 
@@ -906,6 +942,11 @@ Example 1: Enable self enrolment on a course without an enrolment key
 Example 2: Enable self enrolment on a course with an enrolment key
 
     moosh course-enableselfenrol --key "an example enrolment key" 3
+
+Example 3: Enable self enrolment with a custom role assignment, custom instance name, welcome email settings, and a custom welcome message
+
+    moosh course-enableselfenrol --roleid 5 --name "Premium Enrolment" --sendmessage 1 --message "Welcome to our Premium Course!" 3
+
 
 course-info
 -----------


### PR DESCRIPTION
Hi everyone,

First off, thanks a ton for creating this fantastic tool! I've been using it at our university and found it incredibly helpful.

I've made a couple of improvements that I'd like to contribute:

- New Options for course-enableselfenrol: Added --roleid, --name, --sendmessage, and --message options to allow for more flexible self-enrolment configuration. The previous behavior of the existing command should not be altered by the extensions.

- New Command course-enrol-list: This command lists all enrolment instances for a given course in a similar format to course-enrol-change-status, making it easier to see which methods are currently enabled or disabled.

Tested with every LTS version since 3.9. Hope you find these changes useful.