### PR TITLE
Feature #515: Add course restore preprocess

### DIFF
--- a/Moosh/Command/Moodle39/Course/CourseRestore.php
+++ b/Moosh/Command/Moodle39/Course/CourseRestore.php
@@ -19,6 +19,9 @@ class CourseRestore extends MooshCommand {
 
         $this->addArgument('backup_file');
         $this->addArgument('category_id');
+        $this->addArgument('preprocess', );
+        // preprocessing is optional
+        $this->minArguments--;
 
         $this->addOption('d|directory', 'restore from extracted directory (1st param) under tempdir/backup');
         $this->addOption('e|existing', 'restore into existing course, id provided instead of category_id');
@@ -96,6 +99,18 @@ class CourseRestore extends MooshCommand {
             $fp->extract_to_pathname($arguments[0], $path);
         } else {
             $backupdir = $arguments[0];
+        }
+
+        if(!empty($arguments[2])) {
+            if(!file_exists($arguments[2])) {
+                echo "Preprocessing script '" . $arguments[2] . "' does not exist" . PHP_EOL;
+                exit(1);
+            }
+            if($this->verbose) {
+                echo "Using preprocessing script '" . $arguments[2] . "'" . PHP_EOL;
+            }
+            require $arguments[2];
+            moosh_preprocess_mbz($path, $this->verbose);
         }
 
         //extract original full & short names

--- a/Moosh/Command/Moodle39/Course/CourseRestore.php
+++ b/Moosh/Command/Moodle39/Course/CourseRestore.php
@@ -19,14 +19,12 @@ class CourseRestore extends MooshCommand {
 
         $this->addArgument('backup_file');
         $this->addArgument('category_id');
-        $this->addArgument('preprocess', );
-        // preprocessing is optional
-        $this->minArguments--;
 
         $this->addOption('d|directory', 'restore from extracted directory (1st param) under tempdir/backup');
         $this->addOption('e|existing', 'restore into existing course, id provided instead of category_id');
         $this->addOption('o|overwrite', 'restore into existing course, overwrite current content, id provided instead of category_id');
         $this->addOption('i|ignore-warnings', 'continue with restore if there are pre-check warnings');
+        $this->addOption('p|preprocess:', 'provide a path to a backup preprocessing script', '');
     }
 
     public function execute() {
@@ -101,15 +99,15 @@ class CourseRestore extends MooshCommand {
             $backupdir = $arguments[0];
         }
 
-        if(!empty($arguments[2])) {
-            if(!file_exists($arguments[2])) {
-                echo "Preprocessing script '" . $arguments[2] . "' does not exist" . PHP_EOL;
+        if (!empty($options['preprocess'])) {
+            if(!file_exists($options['preprocess'])) {
+                echo "Preprocessing script '" . $options['preprocess'] . "' does not exist" . PHP_EOL;
                 exit(1);
             }
             if($this->verbose) {
-                echo "Using preprocessing script '" . $arguments[2] . "'" . PHP_EOL;
+                echo "Using preprocessing script '" . $options['preprocess'] . "'" . PHP_EOL;
             }
-            require $arguments[2];
+            require $options['preprocess'];
             moosh_preprocess_mbz($path, $this->verbose);
         }
 

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -1104,6 +1104,10 @@ Example 4: Restore backup.mbz into existing course with id=3, overwrite course c
 
     moosh course-restore --overwrite backup.mbz 3
 
+Example 5: Restore backup.mbz into category with id=1 and apply a preprocessing script. The script should define a function `moosh_preprocess_mbz($path: string, $verbose: bool): void`, where `$path` is a path to the unarchived backup and `$verbose` is a verbosity flag.
+
+    moosh course-restore --preprocess preprocessing-script.php backup.mbz 1
+
 course-unenrol
 --------------
 


### PR DESCRIPTION
Closes #515 

As described in the issue, this PR enables Moodle admins to provide a path to a preprocessing script for a MBZ backup. This script is run after unpacking the archive and is expected to contain a function
```php
function moosh_preprocess_mbz($path, $verbose): void
```
where `$path` represents path to a newly unpacked backup archive, which the preprocessing script can modify as needed, and `$verbose` is a verbosity flag.

The script could be provided by adding the option `--preprocess`:
```
course-restore --preprocess ./preprocessing-script.php backup_file category_id
```

This way, Moodle admins can modify the backups they are importing any way they see fit by modifying the XMLs.