### PR TITLE
MSH-517 Fix Subcategory Sorting

### DIFF
--- a/Moosh/Command/Moodle39/Category/CategoryResortCourses.php
+++ b/Moosh/Command/Moodle39/Category/CategoryResortCourses.php
@@ -61,8 +61,13 @@ class CategoryResortCourses extends MooshCommand {
 
     protected function resort($category, $sort, $nocatsort, $nocoursesort) {
         if (!$nocatsort) {
-            $category->resort_subcategories($sort, false);
+            $catsort = 'name';
+            if ($sort == 'idnumber') {
+                $catsort = $sort;
+            }
+            $category->resort_subcategories($catsort, false);
         }
+
         if (!$nocoursesort) {
             $category->resort_courses($sort, false);
         }


### PR DESCRIPTION
This defaults the subcategory sort to `name` if `shortname` or `fullname` are given as arguments; `idnumber` otherwise.

Closes #517.