### PR TITLE
user-login/admin-login: Force HTTPS to avoid redirect notice

### DIFF
--- a/moosh.php
+++ b/moosh.php
@@ -232,6 +232,7 @@ if ($bootstrap_level === MooshCommand::$BOOTSTRAP_NONE) {
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP 1.1';
         $_SERVER['SERVER_SOFTWARE'] = 'PHP /' . phpversion() . ' Development Server';
         $_SERVER['REQUEST_URI'] = '/';
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
     } else {
         define('CLI_SCRIPT', true);
     }


### PR DESCRIPTION
Fixes #409 

When executing `user-login` or `admin-login` commands, you may receive an HTTPS redirect notice. To fix this, we can force HTTPS in the `$_SERVER` variable. Further, if you want to get proper output with curl:
`curl -L -b 'MoodleSession:<session_id>' http://site.name/my/index.php`