### PR TITLE
change all occurances of Twig_[Package] to \\Twig\\[Package]]

### DIFF
--- a/Moosh/Command/Generic/Dev/GenerateMoosh.php
+++ b/Moosh/Command/Generic/Dev/GenerateMoosh.php
@@ -8,9 +8,9 @@
 
 namespace Moosh\Command\Generic\Dev;
 use Moosh\MooshCommand;
-use Twig_Loader_Filesystem;
-use Twig_Environment;
-use Twig_Extension_Debug;
+use \Twig\Loader\FilesystemLoader;
+use \Twig\Environment;
+use \Twig\Extension\Debug;
 
 class GenerateMoosh extends MooshCommand
 {
@@ -28,8 +28,8 @@ class GenerateMoosh extends MooshCommand
 
     public function execute()
     {
-        $loader = new Twig_Loader_Filesystem($this->mooshDir . '/templates');
-        $twig = new Twig_Environment($loader);
+        $loader = new \Twig\Loader\FilesystemLoader($this->mooshDir . '/templates');
+        $twig = new \Twig\Environment($loader);
 
         $command = explode('-', $this->arguments[0], 2);
         if (count($command) != 2) {

--- a/Moosh/Command/Moodle39/Dev/FormAdd.php
+++ b/Moosh/Command/Moodle39/Dev/FormAdd.php
@@ -8,9 +8,9 @@
 
 namespace Moosh\Command\Moodle39\Dev;
 use Moosh\MooshCommand;
-use Twig_Loader_Filesystem;
-use Twig_Environment;
-use Twig_Extension_Debug;
+use \Twig\Loader\Filesystem;
+use \Twig\Environment;
+use \Twig\Extension\Debug;
 
 class FormAdd extends MooshCommand
 {
@@ -26,9 +26,9 @@ class FormAdd extends MooshCommand
     public function execute()
     {
 
-        $loader = new Twig_Loader_Filesystem($this->mooshDir.'/templates');
-        $twig = new Twig_Environment($loader,array('debug' => true));
-        $twig->addExtension(new Twig_Extension_Debug());
+        $loader = new \Twig\Loader\Filesystem($this->mooshDir.'/templates');
+        $twig = new \Twig\Environment($loader,array('debug' => true));
+        $twig->addExtension(new \Twig\Extension\Debug());
 
         $template = 'form/form-element-' . $this->arguments[0] . '.twig';
         if (!$loader->exists($template)) {

--- a/Moosh/Command/Moodle39/Dev/GenerateFilemanager.php
+++ b/Moosh/Command/Moodle39/Dev/GenerateFilemanager.php
@@ -8,9 +8,9 @@
 
 namespace Moosh\Command\Moodle39\Dev;
 use Moosh\MooshCommand;
-use Twig_Loader_Filesystem;
-use Twig_Environment;
-use Twig_Extension_Debug;
+use \Twig\Loader\Filesystem;
+use \Twig\Environment;
+use \Twig\Extension\Debug;
 
 class GenerateFilemanager extends MooshCommand
 {
@@ -22,9 +22,9 @@ class GenerateFilemanager extends MooshCommand
 
     public function execute()
     {
-        $loader = new Twig_Loader_Filesystem($this->mooshDir.'/templates');
-        $twig = new Twig_Environment($loader,array('debug' => true));
-        $twig->addExtension(new Twig_Extension_Debug());
+        $loader = new \Twig\Loader\Filesystem($this->mooshDir.'/templates');
+        $twig = new \Twig\Environment($loader,array('debug' => true));
+        $twig->addExtension(new \Twig\Extension\Debug());
 
         foreach(array('filemanager/form-handler.twig','filemanager/display.twig','filemanager/lib.twig') as $template) {
             echo $twig->render($template, array('id' =>  $this->pluginInfo['type'] .'_'. $this->pluginInfo['name']));

--- a/Moosh/Command/Moodle39/Dev/GenerateForm.php
+++ b/Moosh/Command/Moodle39/Dev/GenerateForm.php
@@ -8,8 +8,8 @@
 
 namespace Moosh\Command\Moodle39\Dev;
 use Moosh\MooshCommand;
-use Twig_Loader_Filesystem;
-use Twig_Environment;
+use \Twig\Loader\Filesystem;
+use \Twig\Environment;
 
 class GenerateForm extends MooshCommand
 {
@@ -25,8 +25,8 @@ class GenerateForm extends MooshCommand
         //command may need to store some information in-between runs
         $this->loadSession();
 
-        $loader = new Twig_Loader_Filesystem($this->mooshDir.'/templates');
-        $twig = new Twig_Environment($loader);
+        $loader = new \Twig\Loader\Filesystem($this->mooshDir.'/templates');
+        $twig = new \Twig\Environment($loader);
 
         $formName = '';
         if ($this->pluginInfo['type'] != 'unknown') {


### PR DESCRIPTION
fixes 'Class "Twig_Loader_Filesystem" not found' error in generate-moosh