### PR TITLE
Add Config import and export commands

### DIFF
--- a/Moosh/Command/Moodle39/Config/ConfigExport.php
+++ b/Moosh/Command/Moodle39/Config/ConfigExport.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This command exports Moodle configuration settings to a JSON file.
+ *
+ * Usage:
+ *   moosh config export --output-file=path/to/file.json
+ *
+ * Options:
+ *   --output-file: Path to the output file (default: stdout).
+ *
+ * @author     Andrej Vitez <contact@andrejvitez.com>
+ * @copyright  2012 onwards Tomasz Muras
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Config;
+
+use moodle_database;
+use Moosh\MooshCommand;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Class ConfigExport
+ *
+ * @package Moosh\Command\Moodle39\Config
+ */
+class ConfigExport extends MooshCommand {
+    private ?moodle_database $db = null;
+
+    public function __construct() {
+        parent::__construct('export', 'config');
+        $this->addOption(
+            'o|output-file:',
+            'Output file for export (default: stdout).',
+            'php://stdout'
+        );
+    }
+
+    public function execute() {
+        global $DB;
+        $this->db = $DB;
+        $outputfile = $this->expandedOptions['output-file'];
+
+        try {
+            $this->export_config($outputfile);
+        } catch (Throwable $exception) {
+            $this->error(sprintf("Error: %s\nTerminating due to error.", $exception->getMessage()));
+        }
+    }
+
+    private function export_config(string $outputfile): void {
+        $configs = $this->db->get_records('config', [], '', 'name,value');
+        $data = [];
+        foreach ($configs as $config) {
+            $data[$config->name] = $config->value;
+        }
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        if (file_put_contents($outputfile, $json . PHP_EOL) === false) {
+            throw new  RuntimeException(sprintf('Failed to write to output file: %s', $outputfile));
+        }
+        if ($this->verbose) {
+            $this->message(sprintf('Exported %d config values to %s', count($data), $outputfile));
+        }
+    }
+
+    private function message(string $message): void {
+        fwrite(STDERR, $message . PHP_EOL);
+    }
+
+    private function error(string $message): void {
+        fwrite(STDERR, $message . PHP_EOL);
+    }
+}

--- a/Moosh/Command/Moodle39/Config/ConfigImport.php
+++ b/Moosh/Command/Moodle39/Config/ConfigImport.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This commands imports Moodle configuration settings from a JSON file.
+ *
+ * Usage:
+ *   moosh config import --input-file=path/to/file.json [--skip-existing]
+ *
+ * Options:
+ *   --input-file: Path to the input JSON file. (required)
+ *   --skip-existing: Skip existing config values during import. (optional)
+ *
+ * ⚠️ WARNING: This command modifies the database directly and can corrupt your Moodle config if not used carefully.
+ * Always backup your database before running this command.
+ * It is recommended to validate the JSON input before importing.
+ *
+ * @author     Andrej Vitez <contact@andrejvitez.com>
+ * @copyright  2012 onwards Tomasz Muras
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moosh\Command\Moodle39\Config;
+
+use InvalidArgumentException;
+use Moosh\MooshCommand;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Class ConfigImport
+ *
+ * @package Moosh\Command\Moodle39\Config
+ */
+class ConfigImport extends MooshCommand {
+
+    public function __construct() {
+        parent::__construct('import', 'config');
+        $this->addOption(
+            'i|input-file:',
+            'Input JSON file for import.',
+        );
+        $this->addOption(
+            's|skip-existing:',
+            'Skip existing config values during import.',
+        );
+    }
+
+    public function execute() {
+        global $DB;
+        $this->db = $DB;
+        $inputfile = $this->expandedOptions['input-file'];
+
+        if (!$inputfile || !file_exists($inputfile) || !is_readable($inputfile)) {
+            $this->error(sprintf("Input file '%s' does not exist or is not readable.", $inputfile));
+            exit(1);
+        }
+
+        $choice = cli_input(
+            "⚠️ ⚠️ ⚠️  DANGER ⚠️ ⚠️ ⚠️\n"
+            . "Running this command will modify your database and potentially corrupt your \n"
+            . "Moodle config if import payload is not validated carefully.\n"
+            . "Make sure you backup your database first!\n\n"
+            . "Are you sure you want to proceed? (y/n)",
+            'n',
+            ['y', 'n']
+        );
+
+        if ($choice !== 'y') {
+            $this->message('Command canceled.');
+            exit(1);
+        }
+
+        try {
+            $this->import_config($inputfile);
+        } catch (Throwable $exception) {
+            $this->error(sprintf("Error: %s\nTerminating due to error.", $exception->getMessage()));
+        }
+    }
+
+    private function error(string $message): void {
+        fwrite(STDERR, $message . PHP_EOL);
+    }
+
+    private function message(string $message): void {
+        fwrite(STDERR, $message . PHP_EOL);
+    }
+
+    private function import_config(string $inputfile): void {
+        $overwrite = !$this->expandedOptions['skip-existing'];
+
+        if ($this->verbose) {
+            $this->message(sprintf('Importing config from %s with overwrite set to %s', $inputfile, $overwrite ? 'true' : 'false'));
+        }
+
+        if (false === ($json = file_get_contents($inputfile))) {
+            throw new RuntimeException('Failed to read input file: ' . $inputfile);
+        }
+
+        $data = json_decode($json, true);
+        if (!is_array($data)) {
+            throw new InvalidArgumentException('Invalid JSON input.');
+        }
+
+        $count = 0;
+        foreach ($data as $name => $value) {
+            $record_exists = $this->db->record_exists('config', ['name' => $name]);
+            if ($record_exists && $overwrite) {
+                $this->db->set_field('config', 'value', $value, ['name' => $name]);
+            } else if (!$record_exists) {
+                $this->db->insert_record('config', ['name' => $name, 'value' => $value]);
+            }
+            $count++;
+        }
+
+        purge_all_caches();
+        $this->message(sprintf('Imported %d config values and purged all caches.', $count));
+    }
+}

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -733,6 +733,75 @@ Example 2: Set URL to logo for Sky High theme.
 
     moosh config-set logo http://example.com/logo.png theme_sky_high
 
+config-export
+-------------
+
+Exports all Moodle configuration settings from the `mdl_config` table to a JSON file.
+
+This command allows administrators to back up all site configuration values for migration, backup, or review. The output is a JSON file mapping config names to their values.
+
+Available options:
+
+| Option              | Description                                      |
+|---------------------|--------------------------------------------------|
+| -o, --output-file   | Output file for export (default: stdout).        |
+
+Example 1: Export all config values to a file named `config.json`.
+```
+moosh config-export --output-file=config.json
+```
+
+Example 2: Export all config values to stdout.
+```
+moosh config-export
+```
+
+The output file will contain a JSON object, for example:
+```json
+{
+  "sitefullname": "My Moodle Site",
+  "siteshortname": "moodle"
+}
+```
+
+---
+
+config-import
+-------------
+
+Imports Moodle configuration settings from a JSON file into the `mdl_config` table and purges all caches.
+
+This command allows administrators to restore or update site configuration from a previously exported JSON file. By default, existing config values are overwritten. Use the `--skip-existing` option to only insert new config values.
+
+⚠️ **WARNING:** This command modifies the database directly. Always back up your database before running.
+
+Available options:
+
+| Option              | Description                                             |
+|---------------------|---------------------------------------------------------|
+| -i, --input-file    | Input JSON file for import. (required)                  |
+| -s, --skip-existing | Skip existing config values during import. (optional)   |
+
+Example 1: Import config values from `config.json`, overwriting existing values.
+```
+moosh config-import --input-file=config.json
+```
+
+Example 2: Import config values from `config.json`, skipping existing values.
+```
+moosh config-import --input-file=config.json --skip-existing
+```
+
+After import, all Moodle caches are purged automatically.
+
+The input file must be a JSON object mapping config names to values, for example:
+```json
+{
+  "sitefullname": "My Moodle Site",
+  "siteshortname": "moodle"
+}
+```
+
 context-freeze
 --------------
 Freeze or unfreeze a given context


### PR DESCRIPTION
Exports all Moodle configuration settings from the `mdl_config` table to a JSON file.

This command allows administrators to back up all site configuration values for migration, backup, or review. The output is a JSON file mapping config names to their values.

Available options:

| Option              | Description                                      |
|---------------------|--------------------------------------------------|
| -o, --output-file   | Output file for export (default: stdout).        |

Example 1: Export all config values to a file named `config.json`.
```
moosh config-export --output-file=config.json
```

Example 2: Export all config values to stdout.
```
moosh config-export
```

The output file will contain a JSON object, for example:
```json
{
  "sitefullname": "My Moodle Site",
  "siteshortname": "moodle"
}
```

---

config-import
-------------

Imports Moodle configuration settings from a JSON file into the `mdl_config` table and purges all caches.

This command allows administrators to restore or update site configuration from a previously exported JSON file. By default, existing config values are overwritten. Use the `--skip-existing` option to only insert new config values.

⚠️ **WARNING:** This command modifies the database directly. Always back up your database before running.

Available options:

| Option              | Description                                             |
|---------------------|---------------------------------------------------------|
| -i, --input-file    | Input JSON file for import. (required)                  |
| -s, --skip-existing | Skip existing config values during import. (optional)   |

Example 1: Import config values from `config.json`, overwriting existing values.
```
moosh config-import --input-file=config.json
```

Example 2: Import config values from `config.json`, skipping existing values.
```
moosh config-import --input-file=config.json --skip-existing
```

After import, all Moodle caches are purged automatically.

The input file must be a JSON object mapping config names to values, for example:
```json
{
  "sitefullname": "My Moodle Site",
  "siteshortname": "moodle"
}
```