### PR TITLE
fix `group-list --id`

### DIFF
--- a/Moosh/Command/Moodle39/Group/GroupList.php
+++ b/Moosh/Command/Moodle39/Group/GroupList.php
@@ -76,7 +76,7 @@ class GroupList extends MooshCommand {
                             echo "No grouping\n";
                     }
                     foreach ($free_groups as $group) {
-                        if (!empty($options["id"])) { echo $id . "\n"; }
+                        if (!empty($options["id"])) { echo $group->id . "\n"; }
                         else {
                             echo "\tgroup " . $group->id . " \"" . $group->name . "\" " . $group->description . "\n";
                         }


### PR DESCRIPTION
Was printing earlier $id from previous loop over $free_groups (repeating last ID seen)